### PR TITLE
[#66, #67] Turn 'Resource Increase' advancement into an instance on the actor.

### DIFF
--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -22,7 +22,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
           flat: new NumberField({ integer: true, initial: null, required: true }),
           level: new NumberField({ integer: true, initial: null, required: true }),
         }),
-        max: new NumberField({ integer: true, nullable: false, initial: 0, min: 0 }),
+        max: new NumberField({ integer: true, nullable: true, initial: null, min: 0 }),
         spent: new NumberField({ integer: true, nullable: false, initial: 0, min: 0 }),
       });
     };

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -111,10 +111,19 @@ export default class TravelerData extends CreatureData {
 
     // Types, Status Immunities, and Mastered Weapons.
     const { habitat, weapon, statusImmunity, type } = this.advancements.documentsByType;
-    for (const a of weapon) a.prepareBaseData();
-    for (const a of statusImmunity) a.prepareBaseData();
-    for (const a of type) a.prepareBaseData();
-    for (const a of habitat) a.prepareBaseData();
+    for (const advancement of type) {
+      if (advancement.choice.chosen) this.details.type[advancement.choice.chosen]++;
+    }
+    for (const advancement of habitat) {
+      const type = advancement.choice.type;
+      this.mastered[type]?.add(advancement.choice.chosen[type]);
+    }
+    for (const advancement of statusImmunity) {
+      if (advancement.choice.chosen) this.condition.immunities.add(advancement.choice.chosen);
+    }
+    for (const advancement of weapon) {
+      if (advancement.choice.chosen) this.mastered.weapons[advancement.choice.chosen]++;
+    }
   }
 
   /* -------------------------------------------------- */
@@ -186,11 +195,15 @@ export default class TravelerData extends CreatureData {
       const resource = this.resources[key];
       const src = this._source.resources[key];
 
+      const advancementBonus = this.advancements.documentsByType.resource
+        .reduce((acc, advancement) => acc + advancement.choice.chosen[key], 0);
+
       resource.max = src.max
         + resource.bonuses.flat
         + resource.gear
         + resource.bonuses.level * this.details.level
-        + typeBonus;
+        + typeBonus
+        + advancementBonus;
       resource.spent = Math.min(resource.spent, resource.max);
       resource.value = resource.max - resource.spent;
       resource.pct = Math.clamp(Math.round(resource.value / resource.max * 100), 0, 100) || 0;

--- a/code/data/advancement/habitat.mjs
+++ b/code/data/advancement/habitat.mjs
@@ -66,17 +66,4 @@ export default class HabitatAdvancement extends Advancement {
     const data = foundry.utils.expandObject(formData.object);
     return { result: new this({ type: this.TYPE, ...data }, { parent: actor }), type: "advancement" };
   }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-
-    const document = this.document;
-    if (!document) return;
-
-    if (this.choice.type === "terrain") document.system.mastered.terrain.add(this.choice.chosen.terrain);
-    else if (this.choice.type === "weather") document.system.mastered.weather.add(this.choice.chosen.weather);
-  }
 }

--- a/code/data/advancement/resource.mjs
+++ b/code/data/advancement/resource.mjs
@@ -57,11 +57,11 @@ export default class ResourceAdvancement extends Advancement {
   /** @override */
   static _determineResult(actor, formData) {
     formData = foundry.utils.expandObject(formData.object);
-    const source = actor.system._source.resources;
-    const update = {
-      "system.resources.stamina.max": source.stamina.max + formData.choice.chosen.stamina,
-      "system.resources.mental.max": source.mental.max + formData.choice.chosen.mental,
+    formData.type = this.TYPE;
+
+    return {
+      result: new this(formData, { parent: actor }),
+      type: "advancement",
     };
-    return { result: update, type: "actor" };
   }
 }

--- a/code/data/advancement/status-immunity.mjs
+++ b/code/data/advancement/status-immunity.mjs
@@ -37,14 +37,4 @@ export default class StatusImmunityAdvancement extends Advancement {
     const data = foundry.utils.expandObject(formData.object);
     return { result: new this({ type: this.TYPE, ...data }, { parent: actor }), type: "advancement" };
   }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-
-    const document = this.document;
-    if (document && this.choice.chosen) document.system.condition.immunities.add(this.choice.chosen);
-  }
 }

--- a/code/data/advancement/type.mjs
+++ b/code/data/advancement/type.mjs
@@ -37,14 +37,4 @@ export default class TypeAdvancement extends Advancement {
     const data = foundry.utils.expandObject(formData.object);
     return { result: new this({ type: this.TYPE, ...data }, { parent: actor }), type: "advancement" };
   }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-
-    const document = this.document;
-    if (document && this.choice.chosen) document.system.details.type[this.choice.chosen]++;
-  }
 }

--- a/code/data/advancement/weapon.mjs
+++ b/code/data/advancement/weapon.mjs
@@ -37,14 +37,4 @@ export default class WeaponAdvancement extends Advancement {
     const data = foundry.utils.expandObject(formData.object);
     return { result: new this({ type: this.TYPE, ...data }, { parent: actor }), type: "advancement" };
   }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-
-    const document = this.document;
-    if (document && this.choice.chosen) document.system.mastered.weapons[this.choice.chosen]++;
-  }
 }


### PR DESCRIPTION
Adjust 'resource' advancement to perform its changes in data prep rather than a one-time update. This should not affect existing actors, since their existing changes are part of the "base".

Also removes the changes made by advancements in their `prepareBaseData` to the relevant actor subtype as this location makes more sense.

Related: #66, #67.