### PR TITLE
[#59] Implement subclass of `TooltipManager` for enriched tooltips

### DIFF
--- a/code/applications/elements/_types.mjs
+++ b/code/applications/elements/_types.mjs
@@ -17,4 +17,5 @@
  * @property {string|string[]} [classes]        Css classes to apply.
  * @property {boolean} [inline=true]            Render just the custom element?
  * @property {string} [label]                   The label for the header element of the listing's group.
+ * @property {boolean} [tooltips=false]         If true, assigns hoverable tooltips to the documents.
  */

--- a/code/applications/elements/document-list.mjs
+++ b/code/applications/elements/document-list.mjs
@@ -52,9 +52,12 @@ export default class DocumentList extends HTMLElement {
       uuid: entry.document.uuid,
       name: entry.document.name,
       documentName: entry.document.documentName,
-      tooltipText: name,
+      tooltipText: options.tooltips ? null : name,
+      tooltipHtml: options.tooltips
+        ? ryuutama.helpers.interaction.RyuutamaTooltipManager.constructHTML({ uuid: entry.document.uuid })
+        : null,
     }, entry.dataset ?? {});
-    for (const [k, v] of Object.entries(dataset)) element.dataset[k] = v;
+    for (const [k, v] of Object.entries(dataset)) if (v) element.dataset[k] = v;
 
     return element;
   }

--- a/code/applications/sheets/traveler-sheet.mjs
+++ b/code/applications/sheets/traveler-sheet.mjs
@@ -102,21 +102,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaActorSheet {
     const context = await super._prepareContext(options);
 
     // Skills.
-    /** @type {InventoryElementEntry[]} */
-    const skills = [];
-    for (const skill of this.document.items.documentsByType.skill) {
-      const text = await CONFIG.ux.TextEditor.enrichHTML(
-        skill.system.description.value,
-        { rollData: skill.getRollData(), relativeTo: skill },
-      );
-      skills.push({
-        document: skill,
-        dataset: {
-          tooltipHtml: `<p><strong>${skill.name}</strong></p>${text}`,
-        },
-      });
-    }
-    context.skills = skills;
+    context.skills = this.document.items.documentsByType.skill.map(skill => ({ document: skill }));
 
     context.tabs = this._prepareTabs("primary");
     context.inventoryTabs = this._prepareTabs("inventory");

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -1,14 +1,13 @@
-const { HTMLField, NumberField, SchemaField } = foundry.data.fields;
+import BaseData from "./templates/base.mjs";
 
-export default class ContainerData extends foundry.abstract.TypeDataModel {
+const { NumberField, SchemaField } = foundry.data.fields;
+
+export default class ContainerData extends BaseData {
   /** @override */
   static defineSchema() {
-    return {
+    return Object.assign(super.defineSchema(), {
       capacity: new SchemaField({
         max: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
-      }),
-      description: new SchemaField({
-        value: new HTMLField(),
       }),
       price: new SchemaField({
         value: new NumberField({ nullable: false, initial: 1, min: 0, integer: true }),
@@ -16,7 +15,7 @@ export default class ContainerData extends foundry.abstract.TypeDataModel {
       size: new SchemaField({
         value: new NumberField({ nullable: false, initial: 1, choices: () => ryuutama.config.itemSizes }),
       }),
-    };
+    });
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -1,13 +1,11 @@
+import BaseData from "./templates/base.mjs";
+
 const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
-export default class HerbData extends foundry.abstract.TypeDataModel {
+export default class HerbData extends BaseData {
   /** @override */
   static defineSchema() {
-    return {
-      description: new SchemaField({
-        effect: new HTMLField(),
-        value: new HTMLField(),
-      }),
+    return Object.assign(super.defineSchema(), {
       level: new NumberField({ initial: 1, nullable: false, integer: true, min: 1, max: 5 }),
       price: new SchemaField({
         value: new NumberField({ nullable: true, initial: null, min: 0, integer: true }),
@@ -15,6 +13,16 @@ export default class HerbData extends foundry.abstract.TypeDataModel {
       category: new SchemaField({
         value: new StringField({ required: true, initial: "physical", choices: () => ryuutama.config.herbTypes }),
       }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static get HTMLFields() {
+    return {
+      ...super.HTMLFields,
+      effect: new HTMLField(),
     };
   }
 

--- a/code/data/item/skill.mjs
+++ b/code/data/item/skill.mjs
@@ -1,12 +1,3 @@
-const { HTMLField, SchemaField } = foundry.data.fields;
+import BaseData from "./templates/base.mjs";
 
-export default class SkillData extends foundry.abstract.TypeDataModel {
-  /** @override */
-  static defineSchema() {
-    return {
-      description: new SchemaField({
-        value: new HTMLField(),
-      }),
-    };
-  }
-}
+export default class SkillData extends BaseData {}

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -1,17 +1,16 @@
-const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
+import BaseData from "./templates/base.mjs";
 
-export default class SpellData extends foundry.abstract.TypeDataModel {
+const { NumberField, SchemaField, StringField } = foundry.data.fields;
+
+export default class SpellData extends BaseData {
   /** @override */
   static defineSchema() {
-    return {
+    return Object.assign(super.defineSchema(), {
       category: new SchemaField({
         value: new StringField({
           required: true, initial: "incantation",
           choices: () => ryuutama.config.spellCategories,
         }),
-      }),
-      description: new SchemaField({
-        value: new HTMLField(),
       }),
       spell: new SchemaField({
         activation: new SchemaField({
@@ -33,7 +32,7 @@ export default class SpellData extends foundry.abstract.TypeDataModel {
           custom: new StringField({ required: true }),
         }),
       }),
-    };
+    });
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/templates/_module.mjs
+++ b/code/data/item/templates/_module.mjs
@@ -1,2 +1,3 @@
+export { default as BaseData } from "./base.mjs";
 export { default as GearData } from "./gear.mjs";
 export { default as PhysicalData } from "./physical.mjs";

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -1,0 +1,49 @@
+const { HTMLField, SchemaField } = foundry.data.fields;
+
+/**
+ * Base class that all other item data models inherit from.
+ */
+export default class BaseData extends foundry.abstract.TypeDataModel {
+  /** @override */
+  static defineSchema() {
+    return {
+      description: new SchemaField(this.HTMLFields),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Define the HTML fields within `description`.
+   * @type {object}
+   */
+  static get HTMLFields() {
+    return {
+      value: new HTMLField(),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create data for an enriched tooltip.
+   * @returns {Promise<HTMLElement[]>}
+   */
+  async richTooltip() {
+    const enriched = await CONFIG.ux.TextEditor.enrichHTML(this.description.value, {
+      rollData: this.parent.getRollData(), relativeTo: this.parent,
+    });
+    const context = {
+      item: this.parent,
+      enriched,
+    };
+    const htmlString = await foundry.applications.handlebars.renderTemplate(
+      "systems/ryuutama/templates/ui/items/tooltip.hbs",
+      context,
+    );
+
+    const div = document.createElement("DIV");
+    div.innerHTML = htmlString;
+    return div.children;
+  }
+}

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -1,12 +1,11 @@
-const { HTMLField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+import BaseData from "./base.mjs";
 
-export default class PhysicalData extends foundry.abstract.TypeDataModel {
+const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+
+export default class PhysicalData extends BaseData {
   /** @override */
   static defineSchema() {
-    return {
-      description: new SchemaField({
-        value: new HTMLField(),
-      }),
+    return Object.assign(super.defineSchema(), {
       durability: new SchemaField({
         spent: new NumberField({ nullable: false, initial: 0, integer: true, min: 0 }),
       }),
@@ -17,7 +16,7 @@ export default class PhysicalData extends foundry.abstract.TypeDataModel {
       size: new SchemaField({
         value: new NumberField({ nullable: false, initial: 1, choices: () => ryuutama.config.itemSizes }),
       }),
-    };
+    });
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/weapon.mjs
+++ b/code/data/item/weapon.mjs
@@ -1,6 +1,6 @@
 import PhysicalData from "./templates/physical.mjs";
 
-const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 export default class WeaponData extends PhysicalData {
   /** @inheritdoc */

--- a/code/helpers/_module.mjs
+++ b/code/helpers/_module.mjs
@@ -1,2 +1,4 @@
+export * as interaction from "./interaction/_module.mjs";
+
 export { default as Prelocalization } from "./prelocalization.mjs";
 export { default as Enrichers } from "./enrichers.mjs";

--- a/code/helpers/interaction/_module.mjs
+++ b/code/helpers/interaction/_module.mjs
@@ -1,0 +1,1 @@
+export { default as RyuutamaTooltipManager } from "./tooltip-manager.mjs";

--- a/code/helpers/interaction/tooltip-manager.mjs
+++ b/code/helpers/interaction/tooltip-manager.mjs
@@ -1,0 +1,134 @@
+/**
+ * A class responsible for orchestrating tooltips in the system.
+ */
+export default class RyuutamaTooltipManager extends foundry.helpers.interaction.TooltipManager {
+  /**
+   * The currently registered observer.
+   * @type {MutationObserver}
+   */
+  #observer;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Helper handlebars helper to create a `data-tooltip-html` property.
+   * @example <div data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}"></div>
+   * @param {object} options
+   * @returns {string}
+   */
+  static handlebarsHelper(options) {
+    return RyuutamaTooltipManager.constructHTML(options.hash);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Helper method to construct tooltip HTML.
+   * @param {object} options
+   * @returns {string}
+   */
+  static constructHTML(options) {
+    return `<section>
+      <i class="fa-solid fa-spinner fa-spin-pulse loading" data-uuid="${options.uuid}"></i>
+    </section>`;
+  }
+
+  /* -------------------------------------------------- */
+  /*  Methods                                           */
+  /* -------------------------------------------------- */
+
+  /**
+   * Initialize the mutation observer.
+   */
+  observe() {
+    this.#observer?.disconnect();
+    this.#observer = new MutationObserver(this._onMutation.bind(this));
+    this.#observer.observe(this.tooltip, { attributeFilter: ["class"], attributeOldValue: true });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle a mutation event.
+   * @param {MutationRecord[]} mutationList  The list of changes.
+   * @protected
+   */
+  _onMutation(mutationList) {
+    let isActive = false;
+    const tooltip = this.tooltip;
+    for (const { type, attributeName, oldValue } of mutationList) {
+      if ((type === "attributes") && (attributeName === "class")) {
+        const difference = new Set(tooltip.classList).difference(new Set(oldValue?.split(" ")));
+        if (difference.has("active")) isActive = true;
+      }
+    }
+    if (isActive) this._onTooltipActivate();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve an item via uuid when hovering over a loading tooltip,
+   * or replace the tooltip of a JournalEntryPage.
+   */
+  async _onTooltipActivate() {
+    let document;
+    if (this.element?.classList.contains("content-link")) {
+      document = await fromUuid(this.element.dataset.uuid);
+    } else {
+      const loading = this.tooltip.querySelector(".loading")?.dataset.uuid;
+      document = await fromUuid(loading);
+    }
+
+    if (document) this._onHoverDocument(document);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle hovering over a document or custom tooltip and showing rich tooltips if possible.
+   * @param {foundry.abstract.Document} doc   The document.
+   */
+  async _onHoverDocument(doc) {
+    const content = await doc.system?.richTooltip?.();
+    if (!content?.length) return;
+    this.tooltip.replaceChildren(...content);
+    this.tooltip.classList.add(ryuutama.id);
+    requestAnimationFrame(() => this._positionItemTooltip("RIGHT"));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Position a tooltip after rendering.
+   * @param {string} [direction]    The direction to position the tooltip.
+   * @protected
+   */
+  _positionItemTooltip(direction) {
+    const Cls = this.constructor;
+
+    if (!direction) {
+      direction = Cls.TOOLTIP_DIRECTIONS.LEFT;
+      this._setAnchor(direction);
+    }
+
+    const pos = this.tooltip.getBoundingClientRect();
+    const dirs = Cls.TOOLTIP_DIRECTIONS;
+    switch (direction) {
+      case dirs.UP:
+        if (pos.y - Cls.TOOLTIP_MARGIN_PX <= 0) direction = dirs.DOWN;
+        break;
+      case dirs.DOWN:
+        if (pos.y + this.tooltip.offsetHeight > window.innerHeight) direction = dirs.UP;
+        break;
+      case dirs.LEFT:
+        if (pos.x - Cls.TOOLTIP_MARGIN_PX <= 0) direction = dirs.RIGHT;
+        break;
+      case dirs.RIGHT:
+        if (pos.x + this.tooltip.offsetWidth > window.innerWidth) direction = dirs.LEFT;
+        break;
+    }
+
+    this._setAnchor(direction);
+  }
+}

--- a/main.mjs
+++ b/main.mjs
@@ -78,6 +78,8 @@ Hooks.once("init", () => {
   CONFIG.ui.combat = applications.sidebar.tabs.RyuutamaCombatTracker;
   CONFIG.ui.habitat = applications.apps.CurrentHabitat;
 
+  CONFIG.ux.TooltipManager = helpers.interaction.RyuutamaTooltipManager;
+
   // Assign rolls.
   CONFIG.Dice.rolls.unshift(dice.DamageRoll);
   CONFIG.Dice.rolls.unshift(dice.CheckRoll);
@@ -128,12 +130,15 @@ Hooks.once("setup", () => {
   Handlebars.registerHelper({
     "inventory-element": applications.elements.InventoryElement.handlebarsHelper,
     "effects-element": applications.elements.EffectsElement.handlebarsHelper,
+    "ryuutama-tooltip": helpers.interaction.RyuutamaTooltipManager.handlebarsHelper,
   });
 });
 
 /* -------------------------------------------------- */
 
-Hooks.once("ready", () => {});
+Hooks.once("ready", () => {
+  game.tooltip.observe();
+});
 
 /* -------------------------------------------------- */
 

--- a/styles/applications.css
+++ b/styles/applications.css
@@ -2,6 +2,7 @@
 @import url("./sidebar/_styles.css");
 @import url("./sheets/_styles.css");
 @import url("./tables.css");
+@import url("./ui/_styles.css");
 
 ryuutama-icon {
   height: 100%;

--- a/styles/ui/_styles.css
+++ b/styles/ui/_styles.css
@@ -1,0 +1,2 @@
+@import url("./tooltips.css");
+@import url("./item-tooltips.css");

--- a/styles/ui/item-tooltips.css
+++ b/styles/ui/item-tooltips.css
@@ -1,0 +1,15 @@
+#tooltip.ryuutama,
+.ryuutama.locked-tooltip {
+  &:not(.locked-tooltip) {
+    box-shadow: 0 0 2px var(--ryuutama-enriched-tooltip-border);
+  }
+
+  > .tooltip.item {
+    text-align: initial;
+    font-family: Amiri;
+
+    .name {
+      font-family: Amiri;
+    }
+  }
+}

--- a/styles/ui/tooltips.css
+++ b/styles/ui/tooltips.css
@@ -1,0 +1,1 @@
+#tooltip .ryuutama.loading {}

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -45,6 +45,8 @@
     --ryuutama-color-table-row-odd: var(--ryuutama-color-oldlace);
     --ryuutama-color-table-row-even: var(--ryuutama-color-bisque);
     --ryuutama-table-text-color: var(--ryuutama-color-black);
+
+    --ryuutama-enriched-tooltip-border: var(--ryuutama-color-darkblue);
   }
 
   .theme-dark, .themed.theme-dark {
@@ -59,5 +61,7 @@
     --ryuutama-color-table-row-odd: var(--ryuutama-color-oldlace);
     --ryuutama-color-table-row-even: var(--ryuutama-color-bisque);
     --ryuutama-table-text-color: var(--ryuutama-color-black);
+
+    --ryuutama-enriched-tooltip-border: var(--ryuutama-color-bisque);
   }
 }

--- a/templates/sheets/monster-sheet/skills.hbs
+++ b/templates/sheets/monster-sheet/skills.hbs
@@ -1,3 +1,3 @@
 <section data-tab="{{tabs.skills.id}}" class="{{tabs.skills.cssClass}}" data-group="{{tabs.skills.group}}">
-  {{inventory-element documents=skills action="renderItem" inline=false label=(localize "TYPES.Item.skillPl")}}
+  {{inventory-element documents=skills action="renderItem" inline=false label=(localize "TYPES.Item.skillPl") tooltips=true}}
 </section>

--- a/templates/sheets/traveler-sheet/inventory.hbs
+++ b/templates/sheets/traveler-sheet/inventory.hbs
@@ -13,7 +13,7 @@
     <div class="item">
       <label>{{label}}</label>
       {{#if item}}
-      <a data-action="renderItem" data-uuid="{{item.uuid}}" data-tooltip-text="{{item.name}}" data-tooltip-direction="UP">
+      <a data-action="renderItem" data-uuid="{{item.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}">
         <img src="{{img}}" alt="{{item.name}}">
       </a>
       {{else}}
@@ -34,7 +34,7 @@
   <section data-tab="{{id}}" class="tab {{cssClass}}" data-group="inventory">
     {{#each groups}}
     {{#if items.length}}
-    {{inventory-element documents=items action="renderItem" inline=false label=label}}
+    {{inventory-element documents=items action="renderItem" inline=false label=label tooltips=true}}
     {{/if}}
     {{/each}}
   </section>

--- a/templates/sheets/traveler-sheet/skills.hbs
+++ b/templates/sheets/traveler-sheet/skills.hbs
@@ -1,3 +1,3 @@
 <section data-tab="{{tabs.skills.id}}" class="{{tabs.skills.cssClass}}" data-group="{{tabs.skills.group}}">
-  {{inventory-element documents=skills action="renderItem" inline=false label=(localize "TYPES.Item.skillPl")}}
+  {{inventory-element documents=skills action="renderItem" inline=false label=(localize "TYPES.Item.skillPl") tooltips=true}}
 </section>

--- a/templates/sheets/traveler-sheet/spells.hbs
+++ b/templates/sheets/traveler-sheet/spells.hbs
@@ -1,5 +1,5 @@
 <section data-tab="{{tabs.spells.id}}" class="{{tabs.spells.cssClass}}" data-group="{{tabs.spells.group}}">
   {{#each spells}}
-  {{inventory-element documents=documents label=label inline=false action="renderItem"}}
+  {{inventory-element documents=documents label=label inline=false action="renderItem" tooltips=true}}
   {{/each}}
 </section>

--- a/templates/ui/items/tooltip.hbs
+++ b/templates/ui/items/tooltip.hbs
@@ -1,0 +1,4 @@
+<section class="tooltip item">
+  <h4 class="name">{{item.name}}</h4>
+  <section class="content">{{{enriched}}}</section>
+</section>


### PR DESCRIPTION
All the item system models now inherit from a `BaseData` model as the first part of the inheritance chain. This `BaseData` class adds description fields and a `richTooltip` method for the enriched tooltip. Other document subtypes should also implement this method in the future.

The new `RyuutamaTooltipManager` subclasses `TooltipManager` and replaces regular content-link tooltips as well as customized `data-tooltip-html` properties with these enriched tooltips.

A static method is added to this manager to help with the construction of the required html, and a handlebars helper if the construction is within hbs.

Closes #59.