### PR TITLE
[#83] Prevent benefits of equipped items if they are unusable.

### DIFF
--- a/code/applications/apps/check-configuration-dialog.mjs
+++ b/code/applications/apps/check-configuration-dialog.mjs
@@ -158,11 +158,16 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
     context.showCondition = roll.type === "condition";
     context.showAbilities = !roll.formula;
 
+    const weapon = this.actor.system.equipped?.weapon ?? null;
+
     switch (roll.type) {
       case "damage":
       case "accuracy":
-        if (this.actor.type === "traveler") context.subtitle =
-          this.actor.system.equipped.weapon?.name ?? game.i18n.localize("RYUUTAMA.WEAPON.CATEGORIES.unarmed");
+        if (this.actor.type === "traveler") {
+          if (weapon && weapon.system.isUsable) context.subtitle = weapon.name;
+          else if (weapon) context.subtitle = game.i18n.format("RYUUTAMA.ROLL.weaponBroken", { weapon: weapon.name });
+          else context.subtitle = game.i18n.localize("RYUUTAMA.WEAPON.CATEGORIES.unarmed");
+        }
         break;
       case "journey":
         context.subtitle = ryuutama.config.checkTypes.journey.subtypes[roll.journeyId].label;

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -277,7 +277,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
             const w = this.equipped.weapon;
             let abi;
             let bon;
-            if (w) ({ ability: abi, bonus: bon } = w.system.damage);
+            if (w?.system.isUsable) ({ ability: abi, bonus: bon } = w.system.damage);
             else {
               // Unarmed
               abi = ryuutama.config.unarmedConfiguration.damage.ability;
@@ -306,7 +306,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
             let abilities;
             let bonus;
             const w = this.equipped.weapon;
-            if (w) {
+            if (w?.system.isUsable) {
               abilities = [...w.system.accuracy.abilities];
               bonus = w.system.accuracy.bonus;
               roll.accuracy = { weapon: w, consumeStamina: !w.system.isMastered };
@@ -372,7 +372,6 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
 
     // Final step: cleanup.
     if (result.rollConfig.formula) {
-      result.dialogConfig.chooseAbilities = false;
       delete result.rollConfig.abilities;
     }
 

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -175,10 +175,12 @@ export default class TravelerData extends CreatureData {
    */
   #prepareDefense() {
     const { armor, shield } = this.equipped;
-    this.defense.gear = (armor?.system.armor.defense ?? 0) + (shield?.system.armor.defense ?? 0);
+    this.defense.gear =
+      (armor?.system.isUsable ? armor.system.armor.defense : 0)
+      + (shield?.system.isUsable ? shield.system.armor.defense : 0);
 
     this.defense.shieldDodge = this.parent.getFlag(ryuutama.id, "shieldDodge") ?? false;
-    this.defense.dodge = shield?.system.armor.dodge ?? null;
+    this.defense.dodge = shield?.system.isUsable ? shield.system.armor.dodge : 0;
     this.defense.total = Math.max(this.defense.armor + this.defense.gear, this.defense.shieldDodge ? this.defense.dodge : 0);
   }
 
@@ -191,7 +193,7 @@ export default class TravelerData extends CreatureData {
     const { stamina: hp, mental: mp } = this.resources;
     const orichalcum = Object.keys(this._source.equipped)
       .map(key => this.equipped[key])
-      .filter(item => item?.system.modifiers.has("orichalcum"))
+      .filter(item => item?.system.modifiers.has("orichalcum") && item.system.isUsable)
       .length;
     hp.gear = mp.gear = orichalcum * 2;
 

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -30,6 +30,16 @@ export default class PhysicalData extends BaseData {
   /* -------------------------------------------------- */
 
   /**
+   * Can this item be used?
+   * @type {boolean}
+   */
+  get isUsable() {
+    return !this.modifiers.has("broken");
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * The amount this adds to the capacity.
    * @type {number}
    */

--- a/lang/en.json
+++ b/lang/en.json
@@ -327,7 +327,6 @@
         "FIELDS": {
           "category.season.label": "Magic Season",
           "category.value.label": "Type",
-          "description.value.label": "Description",
           "spell.activation.cast.label": "Casting Time",
           "spell.activation.mental.label": "MP Cost",
           "spell.level.label": "Spell Level",
@@ -538,20 +537,21 @@
         "initiative": "Initiative Check",
         "journey": "Journey Check"
       },
-      "title": "Configure {type}: {name}",
-      "situationalBonus": "Situational Bonus",
-      "concentration": "Concentration",
-      "consumeMental": "Consume MP",
-      "consumeFumble": "Spend Fumble Point",
       "abilities": "Abilities",
-      "critical": "Critical",
+      "concentration": "Concentration",
+      "conditionRemoveStatuses": "Remove Statuses",
+      "conditionRemoveStatusesHint": "After updating your condition, remove status effects that no longer apply?",
+      "conditionUpdateScore": "Update Condition",
+      "consumeFumble": "Spend Fumble Point",
+      "consumeMental": "Consume MP",
       "consumeStamina": "Consume Stamina",
-      "unmasteredWeaponHint": "An accuracy check with an unmastered weapon costs 1 HP.",
+      "critical": "Critical",
       "messageFlavor": "{type}",
       "messageFlavorAbilities": "{type} ({abilities})",
-      "conditionUpdateScore": "Update Condition",
-      "conditionRemoveStatuses": "Remove Statuses",
-      "conditionRemoveStatusesHint": "After updating your condition, remove status effects that no longer apply?"
+      "situationalBonus": "Situational Bonus",
+      "title": "Configure {type}: {name}",
+      "unmasteredWeaponHint": "An accuracy check with an unmastered weapon costs 1 HP.",
+      "weaponBroken": "{weapon} (Broken)"
     },
 
     "SETTINGS": {


### PR DESCRIPTION
Adds the `isUsable` getter on `PhysicalData` that determines whether an item can be used and thus grants any benefits.

A broken item is not unequipped as a character may still have a broken item equipped but receive no benefit from it - though it would still not add to capacity in that case.

Closes #83.