### PR TITLE
[#92] Allow for enrichers to grab the actor from item sheets or from locked tooltips

### DIFF
--- a/code/data/active-effect/standard.mjs
+++ b/code/data/active-effect/standard.mjs
@@ -1,3 +1,7 @@
+/**
+ * @import RyuutamaActor from "../../documents/actor.mjs";
+ */
+
 const { SchemaField, StringField } = foundry.data.fields;
 
 export default class StandardData extends foundry.abstract.TypeDataModel {
@@ -21,6 +25,20 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------------- */
 
   /**
+   * Getter for the actor this effect lives on, if any.
+   * @type {RyuutamaActor|null}
+   */
+  get actor() {
+    const effect = this.parent;
+    if (!effect.parent) return null;
+    if (effect.parent instanceof foundry.documents.Actor) return effect.parent;
+    if (effect.parent.parent instanceof foundry.documents.Actor) return effect.parent.parent;
+    return null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Create data for an enriched tooltip.
    * @returns {Promise<HTMLElement[]>}
    */
@@ -30,6 +48,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
     });
     const context = {
       effect: this.parent,
+      actor: this.actor,
       enriched,
     };
     const htmlString = await foundry.applications.handlebars.renderTemplate(

--- a/code/helpers/enrichers.mjs
+++ b/code/helpers/enrichers.mjs
@@ -41,11 +41,20 @@ export default class Enrichers {
         }
         if (formula) rollConfig.formula = formula;
 
-        element.querySelector(".enricher").addEventListener("click", async (event) => {
-          const application = foundry.applications.instances.get(event.currentTarget.closest(".application")?.id);
+        const enricher = element.querySelector(".enricher");
+        if (enricher._hasEvent) return;
+        enricher._hasEvent = true;
+
+        enricher.addEventListener("click", async (event) => {
+          const target = event.currentTarget;
+          const application = foundry.applications.instances.get(target.closest(".application")?.id);
+          const tooltipActor = fromUuidSync(target.closest(".locked-tooltip [data-actor-uuid]")?.dataset.actorUuid);
           let actors = [];
-          if (application?.document instanceof foundry.documents.Actor) actors = [application.document];
+          if (tooltipActor instanceof foundry.documents.Actor) actors = [tooltipActor];
+          else if (application?.document instanceof foundry.documents.Actor) actors = [application.document];
+          else if (application?.document?.actor instanceof foundry.documents.Actor) actors = [application.document.actor];
           else actors = new Set(canvas.tokens.controlled.map(token => token.actor).filter(_ => _));
+
           for (const actor of actors) {
             await actor.system.rollCheck(rollConfig);
           }

--- a/templates/ui/effects/tooltip.hbs
+++ b/templates/ui/effects/tooltip.hbs
@@ -1,4 +1,4 @@
-<section class="tooltip effect">
+<section class="tooltip effect" {{#if actor}} data-actor-uuid="{{actor.uuid}}" {{/if}}>
   <h4 class="name">{{effect.name}}</h4>
   <section class="content">{{{enriched}}}</section>
 </section>

--- a/templates/ui/items/tooltip.hbs
+++ b/templates/ui/items/tooltip.hbs
@@ -1,4 +1,4 @@
-<section class="tooltip item">
+<section class="tooltip item" {{#if item.actor}} data-actor-uuid="{{item.actor.uuid}}" {{/if}}>
   <h4 class="name">{{item.name}}</h4>
   <section class="content">{{{enriched}}}</section>
   {{#if item.system.modifierLabels.length}}


### PR DESCRIPTION
Closes #92.