### PR TITLE
[#29] Add terrain data to Herb items

### DIFF
--- a/code/applications/sheets/item-sheet.mjs
+++ b/code/applications/sheets/item-sheet.mjs
@@ -76,6 +76,23 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
         this.document.system.description.effect,
         { rollData: this.document.getRollData(), relativeTo: this.document },
       );
+
+      const herbLevelOptions = Array.fromRange(5, 1).map(n => {
+        return { value: n, label: game.i18n.localize(`RYUUTAMA.ITEM.HERB.terrainLevel${n}`) };
+      });
+      const herbTypes = [
+        { value: "", label: game.i18n.localize("RYUUTAMA.ITEM.HERB.anyTerrain") },
+      ];
+      for (const k in ryuutama.config.terrainTypes) {
+        const { label, level } = ryuutama.config.terrainTypes[k];
+        if (level === this.document.system.terrain.level) herbTypes.push({
+          label,
+          value: k,
+          group: game.i18n.localize("RYUUTAMA.ITEM.HERB.specificTerrain"),
+        });
+      }
+      context.herbTypes = herbTypes;
+      context.herbLevelOptions = herbLevelOptions;
     }
 
     if (context.isSpell) {

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -130,13 +130,13 @@ export const experienceLevels = [
  */
 export const herbTypes = {
   enhance: {
-    label: "RYUUTAMA.HERB.CATEGORIES.enhance",
+    label: "RYUUTAMA.ITEM.HERB.CATEGORIES.enhance",
   },
   mental: {
-    label: "RYUUTAMA.HERB.CATEGORIES.mental",
+    label: "RYUUTAMA.ITEM.HERB.CATEGORIES.mental",
   },
   physical: {
-    label: "RYUUTAMA.HERB.CATEGORIES.physical",
+    label: "RYUUTAMA.ITEM.HERB.CATEGORIES.physical",
   },
 };
 Prelocalization.prelocalize(herbTypes);

--- a/lang/en.json
+++ b/lang/en.json
@@ -325,6 +325,33 @@
         "capacity": "Capacity"
       },
 
+      "HERB": {
+        "FIELDS": {
+          "category.value.label": "Type",
+          "description.effect.label": "Use",
+          "price.value.label": "Gold Value",
+          "terrain.level.label": "Terrain Level",
+          "terrain.type.label": "Specific Terrain",
+          "terrain.details.label": "Terrain Details"
+        },
+
+        "CATEGORIES": {
+          "enhance": "Enhance Type",
+          "mental": "Mental Type",
+          "physical": "Physical Type"
+        },
+
+        "terrainLevel1": "1st-level terrain",
+        "terrainLevel2": "2nd-level terrain",
+        "terrainLevel3": "3rd-level terrain",
+        "terrainLevel4": "4th-level terrain",
+        "terrainLevel5": "5th-level terrain",
+        "specificTerrain": "Specific Terrain",
+        "anyTerrain": "Any Terrain",
+
+        "configuration": "Herb Details"
+      },
+
       "SPELL": {
         "FIELDS": {
           "category.season.label": "Magic Season",
@@ -400,19 +427,6 @@
       }
     },
     "CAPE": {},
-    "HERB": {
-      "FIELDS": {
-        "category.value.label": "Type",
-        "description.effect.label": "Use",
-        "level.label": "Level",
-        "price.value.label": "Gold Value"
-      },
-      "CATEGORIES": {
-        "enhance": "Enhance Type",
-        "mental": "Mental Type",
-        "physical": "Physical Type"
-      }
-    },
     "SHIELD": {
       "FIELDS": {
         "armor.penalty.label": "Penalty",

--- a/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/barrierwood-stalk-barrierwoodstalk.json
+++ b/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/barrierwood-stalk-barrierwoodstalk.json
@@ -4,7 +4,6 @@
   "folder": "enhance000000000",
   "type": "herb",
   "system": {
-    "level": 5,
     "category": {
       "value": "enhance"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "alpine",
+      "level": 5,
+      "details": ""
     }
   },
   "img": "icons/magic/nature/tree-bare-glow-yellow.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688486851,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/black-temple-melon-blacktemplemelon.json
+++ b/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/black-temple-melon-blacktemplemelon.json
@@ -4,7 +4,6 @@
   "folder": "enhance000000000",
   "type": "herb",
   "system": {
-    "level": 4,
     "category": {
       "value": "enhance"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "desert",
+      "level": 4,
+      "details": ""
     }
   },
   "img": "icons/consumables/fruit/plum-ripe-purple.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688477779,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/firefly-darkpouch-fireflydarkpouch.json
+++ b/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/firefly-darkpouch-fireflydarkpouch.json
@@ -4,7 +4,6 @@
   "folder": "enhance000000000",
   "type": "herb",
   "system": {
-    "level": 3,
     "category": {
       "value": "enhance"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "details": "Night only",
+      "level": 3,
+      "type": ""
     }
   },
   "img": "icons/commodities/flowers/blooms-purple.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688449299,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/kingmilk-salve-kingmilksalve000.json
+++ b/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/kingmilk-salve-kingmilksalve000.json
@@ -1,10 +1,9 @@
 {
-  "name": "Kingmilk Elixer",
-  "_id": "kingmilkelixer00",
+  "name": "Kingmilk Salve",
+  "_id": "kingmilksalve000",
   "folder": "enhance000000000",
   "type": "herb",
   "system": {
-    "level": 4,
     "category": {
       "value": "enhance"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "jungle",
+      "level": 4,
+      "details": ""
     }
   },
   "img": "icons/commodities/materials/slime-white.webp",
@@ -29,10 +33,10 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688458969,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },
-  "_key": "!items!kingmilkelixer00"
+  "_key": "!items!kingmilksalve000"
 }

--- a/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/windcrying-tulip-windcryingtulip0.json
+++ b/src/items/healing-herbs-herbs00000000000/enhance-type-enhance000000000/windcrying-tulip-windcryingtulip0.json
@@ -4,7 +4,6 @@
   "folder": "enhance000000000",
   "type": "herb",
   "system": {
-    "level": 4,
     "category": {
       "value": "enhance"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "jungle",
+      "details": "Only during strong winds",
+      "level": 4
     }
   },
   "img": "icons/commodities/flowers/lotus-purple.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688468807,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/churchbell-dayflower-churchbelldayflo.json
+++ b/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/churchbell-dayflower-churchbelldayflo.json
@@ -4,7 +4,6 @@
   "folder": "mental0000000000",
   "type": "herb",
   "system": {
-    "level": 2,
     "category": {
       "value": "mental"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "highlands",
+      "level": 2,
+      "details": ""
     }
   },
   "img": "icons/commodities/flowers/lily-bloom.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688397123,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/moonlight-snowgrass-moonlightsnowgra.json
+++ b/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/moonlight-snowgrass-moonlightsnowgra.json
@@ -4,7 +4,6 @@
   "folder": "mental0000000000",
   "type": "herb",
   "system": {
-    "level": 3,
     "category": {
       "value": "mental"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "deepForest",
+      "level": 3,
+      "details": ""
     }
   },
   "img": "icons/commodities/materials/slime-thick-green.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688411147,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/white-night-chrysanthemum-whitenightchrysa.json
+++ b/src/items/healing-herbs-herbs00000000000/mental-type-mental0000000000/white-night-chrysanthemum-whitenightchrysa.json
@@ -4,7 +4,6 @@
   "folder": "mental0000000000",
   "type": "herb",
   "system": {
-    "level": 3,
     "category": {
       "value": "mental"
     },
@@ -14,6 +13,11 @@
     },
     "price": {
       "value": null
+    },
+    "terrain": {
+      "type": "mountain",
+      "level": 3,
+      "details": ""
     }
   },
   "img": "icons/commodities/flowers/clover-purple.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688418284,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/crowned-morning-glory-crownedmorninggl.json
+++ b/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/crowned-morning-glory-crownedmorninggl.json
@@ -4,7 +4,6 @@
   "folder": "physical00000000",
   "type": "herb",
   "system": {
-    "level": 1,
     "description": {
       "effect": "<p>Used to help ease sleep. Next day's Condition will be 6.</p>",
       "value": "<p>An annual that blooms into several gorgeous flowers. The colors of the flowers can vary between white, violet, crimson, and indigo, depending on the weather.</p>"
@@ -14,6 +13,11 @@
     },
     "category": {
       "value": "physical"
+    },
+    "terrain": {
+      "type": "wasteland",
+      "level": 1,
+      "details": ""
     }
   },
   "img": "icons/commodities/flowers/lily-white.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688311948,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/daybreak-crimsonflower-daybreakcrimsonf.json
+++ b/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/daybreak-crimsonflower-daybreakcrimsonf.json
@@ -4,7 +4,6 @@
   "folder": "physical00000000",
   "type": "herb",
   "system": {
-    "level": 3,
     "description": {
       "effect": "<p>May be used to reroll a Condition Check in order to cure a physical status ailment with +1 bonus.</p>",
       "value": "<p>A thistle that blooms blood red flowers. The stalk produces a powerful narcotic, so care must be taken when handled.</p>"
@@ -14,6 +13,11 @@
     },
     "category": {
       "value": "physical"
+    },
+    "terrain": {
+      "type": "swamp",
+      "level": 3,
+      "details": ""
     }
   },
   "img": "icons/commodities/flowers/buds-red.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688351168,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/demon-lacquer-demonlacquer0000.json
+++ b/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/demon-lacquer-demonlacquer0000.json
@@ -4,7 +4,6 @@
   "folder": "physical00000000",
   "type": "herb",
   "system": {
-    "level": 2,
     "description": {
       "effect": "<p>Enough for 1 poison arrow: add 2 damage to 1 bow attack.</p>",
       "value": "<p>A decidious tree that grows to about 12 feet tall with ash-white bark. A dark sap oozes from cuts in the bark.</p>"
@@ -14,6 +13,11 @@
     },
     "category": {
       "value": "physical"
+    },
+    "terrain": {
+      "type": "woods",
+      "level": 2,
+      "details": ""
     }
   },
   "img": "icons/commodities/wood/log-rough-petrified-white.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688332925,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/giants-palm-giantspalm000000.json
+++ b/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/giants-palm-giantspalm000000.json
@@ -4,7 +4,6 @@
   "folder": "physical00000000",
   "type": "herb",
   "system": {
-    "level": 2,
     "description": {
       "effect": "<p>Used to help ease foot pain. Used after a taking damage from a Movement Check: recover that damage.</p>",
       "value": "<p>An annual that produces light green leaves covered in mucuous. It prefers wet climates.</p>"
@@ -14,6 +13,11 @@
     },
     "category": {
       "value": "physical"
+    },
+    "terrain": {
+      "type": "rocky",
+      "level": 2,
+      "details": ""
     }
   },
   "img": "icons/commodities/flowers/cornflower-gold.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688321018,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/sunset-hime-apple-sunsethimeapple0.json
+++ b/src/items/healing-herbs-herbs00000000000/physical-type-physical00000000/sunset-hime-apple-sunsethimeapple0.json
@@ -4,7 +4,6 @@
   "folder": "physical00000000",
   "type": "herb",
   "system": {
-    "level": 1,
     "description": {
       "effect": "<p>Recover 2 HP</p>",
       "value": "<p>A fruit that resembles an apple. Hime Apples become rich with nourishment as their colors deepen like the sunset.</p>"
@@ -14,6 +13,11 @@
     },
     "category": {
       "value": "physical"
+    },
+    "terrain": {
+      "type": "grassland",
+      "level": 1,
+      "details": ""
     }
   },
   "img": "icons/consumables/fruit/apple-glowing-green.webp",
@@ -29,7 +33,7 @@
     "exportSource": null,
     "coreVersion": "13.350",
     "systemId": "ryuutama",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.1.0",
     "createdTime": 1759688295424,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"

--- a/templates/sheets/item-sheet/details.hbs
+++ b/templates/sheets/item-sheet/details.hbs
@@ -9,10 +9,6 @@
     {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder=document.system.price.total}}
     {{/if}}
 
-    {{#if isHerb}}
-    {{> "item-herb"}}
-    {{/if}}
-
     {{!-- MODIFIERS --}}
     {{#if hasModifiers}}
     {{formGroup systemFields.modifiers value=(ifThen disabled document.system.modifiers source.system.modifiers) type="checkboxes" classes="stacked" disabled=disabled options=modifierOptions}}
@@ -34,6 +30,10 @@
     {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled classes="slim"}}
     {{/if}}
   </fieldset>
+
+  {{#if isHerb}}
+  {{> "item-herb"}}
+  {{/if}}
 
   {{#if isSpell}}
   {{> "item-spell"}}

--- a/templates/sheets/item-sheet/herb.hbs
+++ b/templates/sheets/item-sheet/herb.hbs
@@ -1,17 +1,22 @@
-{{!-- LEVEL --}}
-{{formGroup systemFields.level value=(ifThen disabled document.system.level source.system.level) disabled=disabled type="number" classes="slim"}}
+<fieldset>
+  <legend>{{localize "RYUUTAMA.ITEM.HERB.configuration"}}</legend>
+  {{!-- SUBTYPE --}}
+  {{formGroup systemFields.category.fields.value value=(ifThen disabled document.system.category.value source.system.category.value) disabled=disabled classes="slim"}}
 
-{{!-- SUBTYPE --}}
-{{formGroup systemFields.category.fields.value value=(ifThen disabled document.system.category.value source.system.category.value) disabled=disabled classes="slim"}}
+  {{!-- TERRAIN --}}
+  {{formGroup systemFields.terrain.fields.level value=(ifThen disabled document.system.terrain.level source.system.terrain.level) disabled=disabled options=herbLevelOptions}}
+  {{formGroup systemFields.terrain.fields.type value=(ifThen disabled document.system.terrain.type source.system.terrain.type) disabled=disabled options=herbTypes}}
+  {{formGroup systemFields.terrain.fields.details value=(ifThen disabled document.system.terrain.details source.system.terrain.details) disabled=disabled}}
 
-{{!-- EFFECT DESCRIPTION --}}
-{{#if disabled}}
-{{#if enriched.effect}}
-<section class="description">
-  <h6>{{systemFields.description.fields.effect.label}}</h6>
-  {{{enriched.effect}}}
-</section>
-{{/if}}
-{{else}}
-{{formGroup systemFields.description.fields.effect value=source.system.description.effect height=300}}
-{{/if}}
+  {{!-- EFFECT DESCRIPTION --}}
+  {{#if disabled}}
+  {{#if enriched.effect}}
+  <section class="description">
+    <h6>{{systemFields.description.fields.effect.label}}</h6>
+    {{{enriched.effect}}}
+  </section>
+  {{/if}}
+  {{else}}
+  {{formGroup systemFields.description.fields.effect value=source.system.description.effect height=300}}
+  {{/if}}
+</fieldset>

--- a/templates/ui/items/tooltip.hbs
+++ b/templates/ui/items/tooltip.hbs
@@ -1,11 +1,18 @@
 <section class="tooltip item">
   <h4 class="name">{{item.name}}</h4>
   <section class="content">{{{enriched}}}</section>
+
   {{#if item.system.modifierLabels.length}}
   <section class="modifiers tags">
     {{#each item.system.modifierLabels}}
     <div class="tag">{{this}}</div>
     {{/each}}
+  </section>
+  {{/if}}
+
+  {{#if item.system.terrain.label}}
+  <section class="modifier tags">
+    <div class="tag">{{item.system.terrain.label}}</div>
   </section>
   {{/if}}
 </section>


### PR DESCRIPTION
- Migrated `HerbData#level` to `terrain.level`.
- Reconfigured sheet for herb items and added more terrain data.
- Added terrain tag to herb's enriched tooltip.
- Moved herb-specific i18n into `RYUUTAMA.ITEM.HERB`.
- Fixed name of Kingmilk Salve.
- Updated herb items in compendium with new data.

Closes #29.