### PR TITLE
[#97] Allow for HP to go into the negatives.

### DIFF
--- a/code/data/actor/monster.mjs
+++ b/code/data/actor/monster.mjs
@@ -96,19 +96,26 @@ export default class MonsterData extends CreatureData {
    * Prepare resources.
    */
   #prepareResources() {
-    const setupResource = key => {
+    const setupResource = (key, allowNegative = false) => {
       const resource = this.resources[key];
       const src = this._source.resources[key];
 
       resource.max = src.max
         + resource.bonuses.flat
         + resource.bonuses.level * this.details.level;
-      resource.spent = Math.min(resource.spent, resource.max);
+      resource.spent = allowNegative ? resource.spent : Math.min(resource.spent, resource.max);
       resource.value = resource.max - resource.spent;
-      resource.pct = Math.clamp(Math.round(resource.value / resource.max * 100), 0, 100) || 0;
+
+      if (allowNegative && (resource.value < 0)) {
+        resource.pct = Math.clamp(Math.round(Math.abs(resource.value) / this.condition.value * 100), 0, 100) || 0;
+        resource.negative = true;
+      } else {
+        resource.pct = Math.clamp(Math.round(resource.value / resource.max * 100), 0, 100) || 0;
+        resource.negative = false;
+      }
     };
 
-    setupResource("stamina");
+    setupResource("stamina", true);
     setupResource("mental");
   }
 }

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -27,7 +27,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
         shape: new SchemaField({
           high: new StringField({ required: true, blank: true, choices: () => ryuutama.config.abilityScores }),
         }),
-        value: new NumberField({ nullable: true, initial: null, integer: true }),
+        value: new NumberField({ nullable: false, initial: 4, integer: true, min: 2 }),
       }),
       defense: new SchemaField({
         armor: new NumberField({ min: 0, initial: null, integer: true, nullable: true }),
@@ -97,7 +97,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
 
     // Store current HP for later comparison.
     if (foundry.utils.hasProperty(changes, "system.resources.stamina.spent")) {
-      CreatureData.#staminaChange.set(this.parent.uuid, this.resources.stamina.value);
+      CreatureData.#staminaChange.set(this.parent.uuid, this.resources.stamina.spent);
     }
   }
 
@@ -108,7 +108,7 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
     super._onUpdate(changed, options, userId);
 
     if (CreatureData.#staminaChange.has(this.parent.uuid)) {
-      const delta = this.resources.stamina.value - CreatureData.#staminaChange.get(this.parent.uuid);
+      const delta = CreatureData.#staminaChange.get(this.parent.uuid) - this.resources.stamina.spent;
       CreatureData.#staminaChange.delete(this.parent.uuid);
       CreatureData.#displayScrollingDamageNumbers(this.parent, delta);
     }

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -206,7 +206,7 @@ export default class TravelerData extends CreatureData {
       .length;
     hp.gear = mp.gear = orichalcum * 2;
 
-    const setupResource = (key, typeBonus) => {
+    const setupResource = (key, typeBonus, allowNegative = false) => {
       const resource = this.resources[key];
       const src = this._source.resources[key];
 
@@ -219,12 +219,19 @@ export default class TravelerData extends CreatureData {
         + resource.bonuses.level * this.details.level
         + typeBonus
         + advancementBonus;
-      resource.spent = Math.min(resource.spent, resource.max);
+      resource.spent = allowNegative ? resource.spent : Math.min(resource.spent, resource.max);
       resource.value = resource.max - resource.spent;
-      resource.pct = Math.clamp(Math.round(resource.value / resource.max * 100), 0, 100) || 0;
+
+      if (allowNegative && (resource.value < 0)) {
+        resource.pct = Math.clamp(Math.round(Math.abs(resource.value) / this.condition.value * 100), 0, 100) || 0;
+        resource.negative = true;
+      } else {
+        resource.pct = Math.clamp(Math.round(resource.value / resource.max * 100), 0, 100) || 0;
+        resource.negative = false;
+      }
     };
 
-    setupResource("stamina", 4 * this.details.type.attack);
+    setupResource("stamina", 4 * this.details.type.attack, true);
     setupResource("mental", 4 * this.details.type.magic);
   }
 

--- a/code/documents/actor.mjs
+++ b/code/documents/actor.mjs
@@ -48,8 +48,9 @@ export default class RyuutamaActor extends foundry.documents.Actor {
       : isSpent ? (object.max - value) : value;
     if (update === current) return this;
 
+    const allowNegative = attribute === "resources.stamina";
     const updates = {
-      [`system.${attribute}.${isSpent ? "spent" : "value"}`]: Math.clamp(update, 0, object.max),
+      [`system.${attribute}.${isSpent ? "spent" : "value"}`]: Math.clamp(update, 0, allowNegative ? Infinity : object.max),
     };
 
     const allowed = Hooks.call("modifyTokenAttribute", { attribute, value, isDelta, isBar }, updates, this);

--- a/styles/sheets/actor-sheet.css
+++ b/styles/sheets/actor-sheet.css
@@ -56,6 +56,9 @@
 
     &.stamina {
       --color: var(--ryuutama-color-resource-stamina);
+      &.negative {
+        --color: var(--ryuutama-color-resource-stamina-negative);
+      }
     }
     &.mental {
       --color: var(--ryuutama-color-resource-mental);

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -17,6 +17,7 @@
 
   /* VARIABLES */
   --ryuutama-color-resource-stamina: var(--ryuutama-color-limegreen);
+  --ryuutama-color-resource-stamina-negative: var(--ryuutama-color-indianred);
   --ryuutama-color-resource-mental: var(--ryuutama-color-darkblue);
   --ryuutama-color-resource-default: var(--ryuutama-color-black);
 

--- a/templates/sheets/shared/resources.hbs
+++ b/templates/sheets/shared/resources.hbs
@@ -1,7 +1,7 @@
 <div class="form-group wide">
   <label>{{localize "RYUUTAMA.ACTOR.HP"}}</label>
   <div class="form-fields">
-    <resource-bar resource="system.resources.stamina" class="stamina" id="{{rootId}}-stamina"></resource-bar>
+    <resource-bar resource="system.resources.stamina" class="stamina {{#if this.document.system.resources.stamina.negative}} negative {{/if}}" id="{{rootId}}-stamina"></resource-bar>
     {{#unless disabled}}
     <button type="button" data-action="configure" data-config="resource" data-resource="stamina" class="icon fa-solid fa-cog"></button>
     {{/unless}}


### PR DESCRIPTION
Adjusts the input on the token HUD to prevent clamping for stamina, and adds visuals on the actor sheet:

<img width="1220" height="789" alt="image" src="https://github.com/user-attachments/assets/df3d8b6b-acdf-46d2-8e86-fc269aec184b" />

In addition, `condition.value` is now a non-nullable field with a minimum value of 2, and an initial value of 4.

Closes #97.