### PR TITLE
[#28] Implement 'animal' item type

### DIFF
--- a/code/_types.mjs
+++ b/code/_types.mjs
@@ -8,6 +8,26 @@
 /* -------------------------------------------------- */
 
 /**
+ * @typedef AnimalTypeConfig
+ * @property {string} label         Human-readable label.
+ * @property {number} price         Default base price.
+ * @property {number} [ride]        Number of people who can ride this animal. If non-zero, it is assumed this grants
+ *                                  a +1 bonus to travel checks on topographies of Level 2 or less.
+ * @property {number} [capacity]    Carrying capacity of this animal.
+ */
+
+/* -------------------------------------------------- */
+
+/**
+ * @typedef AnimalModifierConfig
+ * @property {string} label         Human-readable label.
+ * @property {number} cost          A multiplicative modifier on the base cost.
+ * @property {boolean} [additive]   If `true`, the `cost` property is addtive.
+ */
+
+/* -------------------------------------------------- */
+
+/**
  * @typedef CheckTypeConfig
  * @property {string} label                                   Human-readable label.
  * @property {Record<string, { string: label }>} [subtypes]   Subtypes of this kind of check.

--- a/code/applications/sheets/traveler-sheet.mjs
+++ b/code/applications/sheets/traveler-sheet.mjs
@@ -130,7 +130,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaActorSheet {
       {
         id: "containers",
         cssClass: context.inventoryTabs.containers.cssClass,
-        groups: [this.#prepareInventoryGroup("container")],
+        groups: [this.#prepareInventoryGroup("container"), this.#prepareInventoryGroup("animal")],
         tiles: true,
       },
     ];

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -2,10 +2,10 @@ import Prelocalization from "./helpers/prelocalization.mjs";
 
 /**
  * @import {
- * AbilityScoreConfig, CheckTypeConfig, EffectExpirationTypeConfig, HerbTypeConfig, ItemModifierConfig, ItemSizeConfig,
- * MonsterCategoryConfig, SeasonConfig, SpellCategoryConfig, SpellActivationTypeConfig, SpellDurationTypeConfig,
- * SpellLevelConfig, SpellRangeTypeConfig, StatusEffectConfig, TerrainTypeConfig, TravelerTypeConfig, UnarmedConfiguration,
- * WeaponCategoryConfig, WeatherTypeConfig
+ * AbilityScoreConfig, AnimalModifierConfig, AnimalTypeConfig, CheckTypeConfig, EffectExpirationTypeConfig, HerbTypeConfig,
+ * ItemModifierConfig, ItemSizeConfig, MonsterCategoryConfig, SeasonConfig, SpellCategoryConfig, SpellActivationTypeConfig,
+ * SpellDurationTypeConfig, SpellLevelConfig, SpellRangeTypeConfig, StatusEffectConfig, TerrainTypeConfig,
+ * TravelerTypeConfig, UnarmedConfiguration, WeaponCategoryConfig, WeatherTypeConfig
  * } from "./_types.mjs";
  */
 
@@ -55,6 +55,80 @@ export const advancement = {
   9: new Set(["resource"]),
   10: new Set(["resource", "statIncrease"]),
 };
+
+/* -------------------------------------------------- */
+/*   Animals                                          */
+/* -------------------------------------------------- */
+
+/**
+ * @type {Record<string, AnimalModifierConfig>}
+ */
+export const animalModifiers = {
+  baby: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.baby",
+    cost: 3 / 10,
+  },
+  badAttitude: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.badAttitude",
+    cost: 7 / 10,
+  },
+  clever: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.clever",
+    cost: 3,
+  },
+  loud: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.loud",
+    cost: 7 / 10,
+  },
+  loyal: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.loyal",
+    cost: 1000,
+    additive: true,
+  },
+  tough: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.tough",
+    cost: 2,
+  },
+  wellTraveled: {
+    label: "RYUUTAMA.ITEM.ANIMAL.MODIFIERS.wellTraveled",
+    cost: 5000,
+    additive: true,
+  },
+};
+Prelocalization.prelocalize(animalModifiers);
+
+/* -------------------------------------------------- */
+
+/**
+ * @type {Record<string, AnimalTypeConfig>}
+ */
+export const animalTypes = {
+  riding: {
+    label: "RYUUTAMA.ITEM.ANIMAL.TYPES.riding",
+    price: 900,
+    ride: 1,
+  },
+  ridingLarge: {
+    label: "RYUUTAMA.ITEM.ANIMAL.TYPES.ridingLarge",
+    price: 3800,
+    ride: 4,
+  },
+  pack: {
+    label: "RYUUTAMA.ITEM.ANIMAL.TYPES.pack",
+    price: 500,
+    capacity: 15,
+  },
+  packLarge: {
+    label: "RYUUTAMA.ITEM.ANIMAL.TYPES.packLarge",
+    price: 2000,
+    capacity: 30,
+  },
+  pet: {
+    label: "RYUUTAMA.ITEM.ANIMAL.TYPES.pet",
+    price: 300,
+  },
+};
+Prelocalization.prelocalize(animalTypes);
 
 /* -------------------------------------------------- */
 

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -251,7 +251,7 @@ export default class TravelerData extends CreatureData {
       const size = item.system.weight ?? 0;
       capacity.value += size;
 
-      if (item.type === "container") {
+      if (["animal", "container"].includes(item.type)) {
         capacity.container += item.system.capacity.max;
       }
     });

--- a/code/data/item/_module.mjs
+++ b/code/data/item/_module.mjs
@@ -1,6 +1,7 @@
 export * as templates from "./templates/_module.mjs";
 
 export { default as AccessoryData } from "./accessory.mjs";
+export { default as AnimalData } from "./animal.mjs";
 export { default as ArmorData } from "./armor.mjs";
 export { default as CapeData } from "./cape.mjs";
 export { default as ContainerData } from "./container.mjs";

--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -1,0 +1,95 @@
+import BaseData from "./templates/base.mjs";
+
+const { NumberField, SetField, SchemaField, StringField } = foundry.data.fields;
+
+export default class AnimalData extends BaseData {
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      capacity: new SchemaField({
+        max: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
+        riders: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
+      }),
+      category: new SchemaField({
+        value: new StringField({ required: true, initial: "pet", choices: () => ryuutama.config.animalTypes }),
+      }),
+      modifiers: new SetField(new StringField()),
+      price: new SchemaField({
+        value: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
+      }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "RYUUTAMA.ITEM.ANIMAL",
+  ];
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+
+    this.#preparePrice();
+    this.#prepareCategory();
+    this.#prepareModifierLabels();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare the total price derived from modifiers.
+   */
+  #preparePrice() {
+    const base = ryuutama.config.animalTypes[this.category.value].price;
+
+    const p = this.price;
+    p.bonus = 0;
+    p.multiplier = 1;
+    p.total = p.value ?? base;
+
+    for (const mod of this.modifiers) {
+      const config = ryuutama.config.animalModifiers[mod];
+      if (!config) continue;
+      const { cost, additive } = config;
+      if (additive) p.bonus += cost;
+      else p.multiplier *= cost;
+    }
+
+    p.total = Math.floor(p.total * p.multiplier + p.bonus);
+    p.sell = Math.floor(p.total / 2);
+    p.saleable = p.sell > 0;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare animal properties.
+   */
+  #prepareCategory() {
+    const config = ryuutama.config.animalTypes[this.category.value];
+    this.capacity.canRide = !!config.ride;
+    this.capacity.canCarry = !!config.capacity;
+
+    this.capacity.riders = this.capacity.canRide ? (this.capacity.riders ?? config.ride) : null;
+    this.capacity.max = this.capacity.canCarry ? (this.capacity.max ?? config.capacity) : null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare labels for modifiers.
+   */
+  #prepareModifierLabels() {
+    this.modifierLabels = [];
+    for (const mod of this.modifiers) {
+      const label = ryuutama.config.animalModifiers[mod]?.label;
+      if (label) this.modifierLabels.push(label);
+    }
+    this.modifierLabels.sort((a, b) => a.localeCompare(b));
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,8 @@
     "Item": {
       "accessory": "Accessory",
       "accessoryPl": "Accessories",
+      "animal": "Animal",
+      "animalPl": "Animals",
       "armor": "Armor",
       "armorPl": "Armor",
       "cape": "Cape",
@@ -78,7 +80,7 @@
         "arsenal": "Weapons & Armor",
         "gear": "Traveling Gear",
         "herbs": "Herbs",
-        "containers": "Containers"
+        "containers": "Animals & Containers"
       },
       "CONTEXT": {
         "EFFECT": {
@@ -312,6 +314,35 @@
       "details": "Details",
       "disabledEffects": "Inactive",
       "durability": "Durability ({value}/{max})",
+
+      "ANIMAL": {
+        "FIELDS": {
+          "capacity.max.label": "Carrying Capacity",
+          "capacity.riders.label": "Max Riders",
+          "category.value.label": "Animal Type",
+          "price.value.label": "Gold Value"
+        },
+
+        "MODIFIERS": {
+          "baby": "Baby",
+          "badAttitude": "Bad Attitude",
+          "clever": "Clever",
+          "loud": "Loud",
+          "loyal": "Loyal",
+          "tough": "Tough",
+          "wellTraveled": "Well-Traveled"
+        },
+
+        "TYPES": {
+          "riding": "Riding Animal",
+          "ridingLarge": "Large Riding Animal",
+          "pack": "Pack Animal",
+          "packLarge": "Large Pack Animal",
+          "pet": "Pet Animal"
+        },
+
+        "configuration": "Animal Configuration"
+      },
 
       "CONTAINER": {
         "FIELDS": {

--- a/main.mjs
+++ b/main.mjs
@@ -53,6 +53,7 @@ Hooks.once("init", () => {
 
   CONFIG.Item.documentClass = documents.RyuutamaItem;
   CONFIG.Item.dataModels.accessory = data.item.AccessoryData;
+  CONFIG.Item.dataModels.animal = data.item.AnimalData;
   CONFIG.Item.dataModels.armor = data.item.ArmorData;
   CONFIG.Item.dataModels.cape = data.item.CapeData;
   CONFIG.Item.dataModels.container = data.item.ContainerData;
@@ -143,12 +144,13 @@ Hooks.once("ready", () => {
     "actor-statuses": "systems/ryuutama/templates/sheets/shared/statuses.hbs",
 
     // ITEM PARTIALS
-    "item-weapon": "systems/ryuutama/templates/sheets/item-sheet/weapon.hbs",
-    "item-gear": "systems/ryuutama/templates/sheets/item-sheet/gear.hbs",
-    "item-defense": "systems/ryuutama/templates/sheets/item-sheet/defense.hbs",
-    "item-herb": "systems/ryuutama/templates/sheets/item-sheet/herb.hbs",
+    "item-animal": "systems/ryuutama/templates/sheets/item-sheet/animal.hbs",
     "item-container": "systems/ryuutama/templates/sheets/item-sheet/container.hbs",
+    "item-defense": "systems/ryuutama/templates/sheets/item-sheet/defense.hbs",
+    "item-gear": "systems/ryuutama/templates/sheets/item-sheet/gear.hbs",
+    "item-herb": "systems/ryuutama/templates/sheets/item-sheet/herb.hbs",
     "item-spell": "systems/ryuutama/templates/sheets/item-sheet/spell.hbs",
+    "item-weapon": "systems/ryuutama/templates/sheets/item-sheet/weapon.hbs",
 
     // SHARED PARTIALS
     "document-list": "systems/ryuutama/templates/sheets/shared/document-list.hbs",

--- a/styles/sheets/document-sheet.css
+++ b/styles/sheets/document-sheet.css
@@ -78,4 +78,8 @@
       }
     }
   }
+
+  .sheet-tabs.tabs [data-action=tab] {
+    white-space: nowrap;
+  }
 }

--- a/system.json
+++ b/system.json
@@ -89,6 +89,11 @@
           "description.value"
         ]
       },
+      "animal": {
+        "htmlFields": [
+          "description.value"
+        ]
+      },
       "armor": {
         "htmlFields": [
           "description.value"

--- a/templates/sheets/item-sheet/animal.hbs
+++ b/templates/sheets/item-sheet/animal.hbs
@@ -1,0 +1,15 @@
+<fieldset>
+  <legend>{{localize "RYUUTAMA.ITEM.ANIMAL.configuration"}}</legend>
+  {{!-- ANIMAL TYPE --}}
+  {{formGroup systemFields.category.fields.value value=(ifThen disabled document.system.category.value source.system.category.value) disabled=disabled}}
+
+  {{!-- RIDING CAPACITY --}}
+  {{#if document.system.capacity.canRide}}
+  {{formGroup systemFields.capacity.fields.riders value=(ifThen disabled document.system.capacity.riders source.system.capacity.riders) disabled=disabled classes="slim" placeholder=animal.defaultRiding}}
+  {{/if}}
+
+  {{!-- CARRY CAPACITY --}}
+  {{#if document.system.capacity.canCarry}}
+  {{formGroup systemFields.capacity.fields.max value=(ifThen disabled document.system.capacity.max source.system.capacity.max) disabled=disabled classes="slim" placeholder=animal.defaultCapacity}}
+  {{/if}}
+</fieldset>

--- a/templates/sheets/item-sheet/details.hbs
+++ b/templates/sheets/item-sheet/details.hbs
@@ -31,6 +31,10 @@
     {{/if}}
   </fieldset>
 
+  {{#if isAnimal}}
+  {{> "item-animal"}}
+  {{/if}}
+
   {{#if isHerb}}
   {{> "item-herb"}}
   {{/if}}


### PR DESCRIPTION
- Adds the `animal` item type.
- Adds config objects for animal subtypes and the animal modifiers.

Both `animal` and `container` increase the capacity of the parent actor. In the future, they can both inherit from a common superclass.

Closes #28.