### PR TITLE
[#85] Adjust WeaponAdvancement to read actor's mastered weapons and other WeaponAdvancements in the current chain

### DIFF
--- a/code/data/advancement/advancement.mjs
+++ b/code/data/advancement/advancement.mjs
@@ -57,12 +57,40 @@ export default class Advancement extends PseudoDocument {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  get document() {
+    // If constructed as part of advancement, the document is the direct parent.
+    if (this.isEphemeral) return this.parent;
+    return super.document;
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Is this advancement fully configured?
    * @type {boolean}
    */
   get isConfigured() {
     return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _configure(options = {}) {
+    super._configure(options);
+    Object.defineProperties(this, {
+      isEphemeral: {
+        value: options.isEphemeral ?? false,
+        writable: false,
+        enumerable: false,
+      },
+      chain: {
+        value: options.chain ?? null,
+        writable: false,
+        enumerable: false,
+      },
+    });
   }
 
   /* -------------------------------------------------- */
@@ -97,9 +125,9 @@ export default class Advancement extends PseudoDocument {
   /**
    * Return advancement types that should be available choices
    * depending on this advancement's current configuration.
-   * @returns {Promise<string[]>}
+   * @returns {Promise<Set<string>>}
    */
   async _getChildTypes() {
-    return [];
+    return new Set();
   }
 }

--- a/code/data/advancement/type.mjs
+++ b/code/data/advancement/type.mjs
@@ -57,8 +57,8 @@ export default class TypeAdvancement extends Advancement {
 
   /** @override */
   async _getChildTypes() {
-    const types = [];
-    if (this.choice.chosen === "attack") types.push("weapon");
+    const types = new Set();
+    if (this.choice.chosen === "attack") types.add("weapon");
     return types;
   }
 }

--- a/code/data/advancement/weapon.mjs
+++ b/code/data/advancement/weapon.mjs
@@ -42,6 +42,25 @@ export default class WeaponAdvancement extends Advancement {
 
   /** @override */
   get isConfigured() {
-    return !!this.choice.chosen;
+    if (!this.isEphemeral) return !!this.choice.chosen;
+
+    const choices = [...Object.keys(ryuutama.config.weaponTypes), "unarmed"].filter(type => {
+      return (!this.document.system.mastered.weapons[type] && !this.#sameWeaponChoice(type));
+    });
+
+    return choices.includes(this.choice.chosen);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is there a Weapon advancement other than this one in the level-up chain that has picked a specific weapon?
+   * @param {string} type   The key of the weapon type.
+   * @returns {boolean}
+   */
+  #sameWeaponChoice(type) {
+    return this.chain.nodes.get("weapon").some(({ advancement }) => {
+      return (advancement !== this) && (advancement.choice.chosen === type);
+    });
   }
 }

--- a/code/utils/advancement/node.mjs
+++ b/code/utils/advancement/node.mjs
@@ -163,7 +163,11 @@ export default class AdvancementNode {
    */
   initializeNode() {
     const Cls = ryuutama.data.advancement.Advancement.documentConfig[this.type];
-    const advancement = new Cls({ level: this.level, type: this.type }, { parent: this.actor });
+    const advancement = new Cls({ level: this.level, type: this.type }, {
+      chain: this.chain,
+      isEphemeral: true,
+      parent: this.actor,
+    });
     this.#advancement = advancement;
     return this.advancement;
   }


### PR DESCRIPTION
Closes #85.

During the level-up process, Weapon advancements will read whether the actor has mastered the weapon that is the curent pick or whether any other weapon advancements in the chain have the same pick.

If that is the case, the weapon advancement is incorrectly configured.

For the Noble's feature, since it can master an already mastered weapon, an effect does the job much better than advancements.