### PR TITLE
[#119, #120] Implement `BaseRoll` class

### DIFF
--- a/code/data/actor/_types.mjs
+++ b/code/data/actor/_types.mjs
@@ -44,6 +44,9 @@
 
 /**
  * @typedef CheckMessageConfig
- * @property {boolean} [create]   Should a chat message be created?
- * @property {object} [data]      Data to be used for the chat message. This does not include `rolls` or `content`.
+ * @property {boolean} [create]                         Should a chat message be created?
+ * @property {object} [data]                            Data to be used for the chat message.
+ *                                                      This does not include `rolls` or `content`.
+ * @property {Record<string, boolean>} [rollOptions]    Options for the roll. The effect of these depends on
+ *                                                      the type of check being performed.
  */

--- a/code/dice/_module.mjs
+++ b/code/dice/_module.mjs
@@ -1,2 +1,3 @@
+export { default as BaseRoll } from "./base-roll.mjs";
 export { default as CheckRoll } from "./check-roll.mjs";
 export { default as DamageRoll } from "./damage-roll.mjs";

--- a/code/dice/base-roll.mjs
+++ b/code/dice/base-roll.mjs
@@ -1,0 +1,1 @@
+export default class BaseRoll extends foundry.dice.Roll {}

--- a/code/dice/check-roll.mjs
+++ b/code/dice/check-roll.mjs
@@ -1,4 +1,6 @@
-export default class CheckRoll extends foundry.dice.Roll {
+import BaseRoll from "./base-roll.mjs";
+
+export default class CheckRoll extends BaseRoll {
   /**
    * Is the check a fumble?
    * @type {boolean}

--- a/main.mjs
+++ b/main.mjs
@@ -86,7 +86,9 @@ Hooks.once("init", () => {
   // Assign rolls.
   CONFIG.Dice.rolls.unshift(dice.DamageRoll);
   CONFIG.Dice.rolls.unshift(dice.CheckRoll);
+  CONFIG.Dice.rolls.unshift(dice.BaseRoll);
   Object.assign(CONFIG.Dice, {
+    BaseRoll: dice.BaseRoll,
     CheckRoll: dice.CheckRoll,
     DamageRoll: dice.DamageRoll,
   });


### PR DESCRIPTION
Closes #119, #120.

Factors out a few bits of the check roll pipeline to choose a roll class and configure roll options.