### PR TITLE
Add more properties to `DamageRoll`, ignore armor on Undead from Mythril/Orichalcum damages

### DIFF
--- a/code/data/actor/templates/_types.mjs
+++ b/code/data/actor/templates/_types.mjs
@@ -81,6 +81,11 @@
 
 /**
  * @typedef DamageConfiguration
- * @property {number} value         The damage total.
- * @property {boolean} [magical]    Is this magical damage, e.g., from a spell?
+ * @property {number} value                     The damage total.
+ * @property {object} [options]
+ * @property {boolean} [options.defenseless]    Does this damage ignore defense points?
+ * @property {boolean} [options.magical]        Is this magical damage, e.g., from a spell?
+ * @property {boolean} [options.mythril]        Is this damage from a mythril item?
+ * @property {boolean} [options.orichalcum]     Is this damage from an orichalcum item? Mythril and orichalcum
+ *                                              items ignore Armor points on Undead.
  */

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -553,12 +553,21 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
   calculateDamage(damages = []) {
     damages = foundry.utils.deepClone(damages);
 
-    const { modifiers } = this.defense;
+    /**
+     * Does this damage ignore defense/armor?
+     * @param {DamageConfiguration} damage
+     * @returns {boolean}
+     */
+    const ignoreDefense = damage => {
+      return damage.options?.defenseless
+        || ((this.details?.category === "undead") && (damage.options?.mythril || damage.options?.orichalcum));
+    };
+
     for (const damage of damages) {
-      if (damage.magical) damage.value += modifiers.magical;
+      if (damage.options?.magical) damage.value += this.defense.modifiers.magical;
       else {
-        damage.value += modifiers.physical;
-        damage.value -= this.defense.total;
+        damage.value += this.defense.modifiers.physical;
+        if (!ignoreDefense(damage)) damage.value -= this.defense.total;
       }
       damage.value = Math.max(0, damage.value);
     }

--- a/code/data/chat-message/damage.mjs
+++ b/code/data/chat-message/damage.mjs
@@ -2,6 +2,7 @@ import MessageData from "./templates/message.mjs";
 
 /**
  * @import { DamageConfiguration } from "../actor/templates/_types.mjs";
+ * @import DamageRoll from "../../dice/damage-roll.mjs";
  */
 
 export default class DamageData extends MessageData {
@@ -30,14 +31,29 @@ export default class DamageData extends MessageData {
   /* -------------------------------------------------- */
 
   /**
+   * The valid damage rolls.
+   * @type {DamageRoll[]}
+   */
+  get damageRolls() {
+    return this.parent.rolls.filter(roll => roll instanceof ryuutama.dice.DamageRoll);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * The damage configs that will be applied by this message.
    * @type {DamageConfiguration[]}
    */
   get damages() {
-    return this.parent.rolls.map(roll => {
+    return this.damageRolls.map(roll => {
       return {
         value: roll.total,
-        magical: roll.isMagical,
+        options: {
+          defenseless: roll.isDefenseless,
+          magical: roll.isMagical,
+          mythril: roll.isMythril,
+          orichalcum: roll.isOrichalcum,
+        },
       };
     });
   }
@@ -46,7 +62,7 @@ export default class DamageData extends MessageData {
 
   /** @override */
   async _prepareContext(context) {
-    context.rolls = await Promise.all(this.parent.rolls.map(roll => roll.render()));
+    context.rolls = await Promise.all(this.damageRolls.map(roll => roll.render()));
   }
 
   /* -------------------------------------------------- */

--- a/code/dice/damage-roll.mjs
+++ b/code/dice/damage-roll.mjs
@@ -2,10 +2,39 @@ import CheckRoll from "./check-roll.mjs";
 
 export default class DamageRoll extends CheckRoll {
   /**
+   * Does this instance of damage ignore defense points?
+   */
+  get isDefenseless() {
+    return !!this.options.defenseless;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Is this instance of damage magical?
    * @type {boolean}
    */
   get isMagical() {
     return !!this.options.magical;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is this damage from a mythril item?
+   * @type {boolean}
+   */
+  get isMythril() {
+    return !!this.options.mythril;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is this damage from an orichalcum item?
+   * @type {boolean}
+   */
+  get isOrichalcum() {
+    return !!this.options.orichalcum;
   }
 }


### PR DESCRIPTION
Related: #45.

- Moves the `DamageConfiguration` options into an `options` object.
- Checks for undead, mythril, and orichalcum and ignores defense if so.