### PR TITLE
[#126] Add `standard` combat subtype with objects display

### DIFF
--- a/code/applications/sidebar/tabs/combat.mjs
+++ b/code/applications/sidebar/tabs/combat.mjs
@@ -1,1 +1,47 @@
-export default class RyuutamaCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {}
+export default class RyuutamaCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      addObjects: RyuutamaCombatTracker.#addObjects,
+      toggleObject: RyuutamaCombatTracker.#toggleObject,
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    const combat = game.combats.viewed;
+    if (combat?.system._onRender instanceof Function) {
+      await combat.system._onRender(this.element);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add a new set of 5 objects to the combat.
+   * @param {PointerEvent} event    Initiating click event.
+   * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static #addObjects(event, target) {
+    const combat = game.combats.viewed;
+    if (combat?.type !== "standard") return;
+    combat.system.addObjects(5);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Toggle the disabled state of an object.
+   * @param {PointerEvent} event    Initiating click event.
+   * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static #toggleObject(event, target) {
+    const combat = game.combats.viewed;
+    if (combat?.type !== "standard") return;
+    const id = target.closest("[data-object-id]").dataset.objectId;
+    combat.system.toggleObject(id);
+  }
+}

--- a/code/data/_module.mjs
+++ b/code/data/_module.mjs
@@ -1,11 +1,12 @@
 export * as actor from "./actor/_module.mjs";
-export * as message from "./chat-message/_module.mjs";
+export * as combat from "./combat/_module.mjs";
 export * as effect from "./active-effect/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journalEntryPage from "./journal-entry-page/_module.mjs";
+export * as message from "./chat-message/_module.mjs";
 
-export * as fields from "./fields/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as fields from "./fields/_module.mjs";
 
 export { default as Ability } from "./ability.mjs";
 export { default as PseudoDocument } from "./pseudo-document.mjs";

--- a/code/data/combat/_module.mjs
+++ b/code/data/combat/_module.mjs
@@ -1,0 +1,1 @@
+export { default as StandardData } from "./standard.mjs";

--- a/code/data/combat/standard.mjs
+++ b/code/data/combat/standard.mjs
@@ -1,0 +1,186 @@
+/**
+ * @import RegionDocument from "@client/documents/region.mjs";
+ * @import RyuutamaCombat from "../../documents/combat.mjs";
+ */
+
+const { BooleanField, ForeignDocumentField, SchemaField, StringField, TypedObjectField } = foundry.data.fields;
+
+export default class StandardData extends foundry.abstract.TypeDataModel {
+  /** @override */
+  static defineSchema() {
+    return {
+      battlefield: new SchemaField({
+        backAlly: new ForeignDocumentField(foundry.documents.RegionDocument, { idOnly: true }),
+        backEnemy: new ForeignDocumentField(foundry.documents.RegionDocument, { idOnly: true }),
+        front: new ForeignDocumentField(foundry.documents.RegionDocument, { idOnly: true }),
+      }),
+      objects: new TypedObjectField(new SchemaField({
+        name: new StringField({ required: true }),
+        disabled: new BooleanField(),
+      }), { validateKey: key => foundry.data.validators.isValidId(key) }),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = [
+    "RYUUTAMA.COMBAT.STANDARD",
+  ];
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The back area for allies.
+   * @type {RegionDocument|null}
+   */
+  get allyBackArea() {
+    return this.parent.scene?.regions.get(this.battleField.backAlly) ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The back area for enemies.
+   * @type {RegionDocument|null}
+   */
+  get enemyBackArea() {
+    return this.parent.scene?.regions.get(this.battleField.backEnemy) ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The front area.
+   * @type {RegionDocument|null}
+   */
+  get frontArea() {
+    return this.parent.scene?.regions.get(this.battleField.front) ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+    if (!("scene" in data)) this.parent.updateSource({ scene: canvas?.scene?.id });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    Object.entries(this.objects).forEach(([id, o]) => {
+      o.name ||= game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder");
+      Object.defineProperty(o, "id", { value: id, writable: false, enumerable: false });
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Configure and then add a number of objects.
+   * @param {number} [count=5]    How many to add.
+   * @returns {Promise<RyuutamaCombat|null>}
+   */
+  async addObjects(count = 5) {
+    const ids = Array.fromRange(count).map(() => foundry.utils.randomID());
+
+    const content = document.createElement("DIV");
+    for (const id of ids) {
+      const nameField = this.schema.getField("objects.element.name");
+      content.insertAdjacentElement("beforeend", nameField.toFormGroup(
+        {},
+        {
+          name: `system.objects.${id}.name`,
+          placeholder: game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder"),
+          autofocus: ids[0] === id,
+        },
+      ));
+    }
+    const configuration = await foundry.applications.api.Dialog.input({ content });
+    if (!configuration) return null;
+
+    const update = foundry.utils.expandObject(configuration);
+    for (const id of ids) update.system.objects[id].name ||= "";
+    return this.parent.update(update);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Toggle the disabled state of an object.
+   * @param {string} id   The id of the object to toggle.
+   * @returns {Promise<RyuutamaCombat>}
+   */
+  async toggleObject(id) {
+    const object = this.objects[id];
+    if (!object) throw new Error(`No object with id '${id}' exists in this combat.`);
+    return this.parent.update({ [`system.objects.${id}.disabled`]: !object.disabled });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Remove an object from the encounter.
+   * @param {string} id   The id of the object to remove.
+   * @returns {Promise<RyuutamaCombat>}
+   */
+  async removeObject(id) {
+    return this.parent.update({ [`system.objects.-=${id}`]: null });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform post-render modifications of the combat tracker.
+   * @param {HTMLElement} element   The rendered element.
+   * @returns {Promise<void>}
+   */
+  async _onRender(element) {
+    const header = element.querySelector("[data-application-part=header]");
+    if (header.querySelector(".ryuutama.objects")) return;
+    this.#insertObjects(header);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Insert the objects of the combat in the tracker.
+   * @param {HTMLElement} element   The combat tracker's rendered element.
+   */
+  #insertObjects(element) {
+    const div = document.createElement("DIV");
+    div.classList.add(ryuutama.id, "objects");
+    const isGM = game.user.isGM;
+
+    const header = foundry.utils.parseHTML(`<h4 class="divider">
+      <span>${game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.objects")}<span>
+    </h4>`);
+    if (isGM) {
+      header.insertAdjacentHTML("beforeend",
+        "<button class='icon inline-control fa-solid fa-plus' data-action='addObjects'></button>",
+      );
+    }
+
+    div.insertAdjacentElement("beforeend", header);
+    const objects = foundry.utils.parseHTML("<div class='objects-list'></div>");
+    div.insertAdjacentElement("beforeend", objects);
+    for (const object of Object.values(this.objects)) {
+      const dataset = Object.entries({
+        "object-id": object.id,
+        action: isGM ? "toggleObject" : null,
+        "tooltip-text": object.name,
+      }).filter(k => k[1]).map(([k, v]) => `data-${k}="${v}"`).join(" ");
+
+      objects.insertAdjacentHTML("beforeend", `
+        <button type="button" ${dataset} ${object.disabled ? "disabled" : ""}>
+          <i class="fa-solid fa-box" inert></i>
+        </button>`,
+      );
+    }
+
+    if (isGM || element.childElementCount) element.insertAdjacentElement("beforeend", div);
+  }
+}

--- a/code/documents/combat.mjs
+++ b/code/documents/combat.mjs
@@ -1,4 +1,28 @@
+/**
+ * @import RyuutamaActiveEffect from "./active-effect.mjs";
+ */
+
 export default class RyuutamaCombat extends foundry.documents.Combat {
+  /** @inheritdoc */
+  _initializeSource(data = {}, options = {}) {
+    if (!data.type || (data.type === "base")) data.type = "standard";
+    return super._initializeSource(data, options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+
+    if (!this.active || !game.user.isActiveGM) return;
+
+    // Remove effects that expire upon combat end.
+    this.expireEffects("combatEnd");
+  }
+
+  /* -------------------------------------------------- */
+
   /** @override */
   async rollInitiative(ids, options = {}) {
     ids = typeof ids === "string" ? [ids] : ids;
@@ -12,17 +36,24 @@ export default class RyuutamaCombat extends foundry.documents.Combat {
 
   /* -------------------------------------------------- */
 
-  /** @inheritdoc */
-  _onDelete(options, userId) {
-    super._onDelete(options, userId);
-
-    if (!this.active || !game.user.isActiveGM) return;
-
-    // Remove effects that expire upon combat end.
-    const actors = new Set(this.combatants.map(c => c.actor).filter(_ => _));
-    for (const actor of actors) {
-      const effects = actor.effects.filter(effect => effect.system.expiration.type === "combatEnd");
-      actor.deleteEmbeddedDocuments("ActiveEffect", effects.map(effect => effect.id));
+  /**
+   * Expire effects of a given expiration type.
+   * @param {string} type   Expiration type.
+   * @returns {Promise<RyuutamaActiveEffect[]>}   A promise that resolves to the deleted effects.
+   */
+  async expireEffects(type) {
+    if (!game.user.isGM) {
+      throw new Error("Only a GM can expire effects through the Combat document.");
     }
+
+    const actors = new Set(this.combatants.map(c => c.actor).filter(_ => _));
+    const promises = [];
+    for (const actor of actors) {
+      const effects = actor.effects.filter(effect => effect.system.expiration.type === type);
+      const deleted = actor.deleteEmbeddedDocuments("ActiveEffect", effects.map(effect => effect.id));
+      promises.push(deleted);
+    }
+    const deleted = await Promise.all(promises);
+    return deleted.flat(1);
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -275,6 +275,20 @@
       }
     },
 
+    "COMBAT": {
+      "STANDARD": {
+        "FIELDS": {
+          "battlefield.backAlly.label": "Ally Back Area",
+          "battlefield.backEnemy.label": "Enemy Back Area",
+          "battlefield.front.label": "Front Area",
+          "objects.element.name.label": "Object Name",
+          "objects.element.name.placeholder": "Object"
+        },
+
+        "objects": "Objects"
+      }
+    },
+
     "EFFECT": {
       "STATUS": {
         "FIELDS": {

--- a/main.mjs
+++ b/main.mjs
@@ -51,6 +51,8 @@ Hooks.once("init", () => {
   CONFIG.ChatMessage.dataModels.standard = data.message.StandardData;
 
   CONFIG.Combat.documentClass = documents.RyuutamaCombat;
+  CONFIG.Combat.dataModels.standard = data.combat.StandardData;
+
   CONFIG.Combatant.documentClass = documents.RyuutamaCombatant;
   CONFIG.CombatantGroup.documentClass = documents.RyuutamaCombatantGroup;
 

--- a/styles/sidebar/_styles.css
+++ b/styles/sidebar/_styles.css
@@ -1,1 +1,2 @@
 @import url("./actors.css");
+@import url("./combats.css");

--- a/styles/sidebar/combats.css
+++ b/styles/sidebar/combats.css
@@ -1,0 +1,9 @@
+#combat, #combat-popout {
+  .ryuutama.objects {
+    .objects-list {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 5px;
+    }
+  }
+}

--- a/system.json
+++ b/system.json
@@ -85,6 +85,9 @@
       "effect": {},
       "standard": {}
     },
+    "Combat": {
+      "standard": {}
+    },
     "Item": {
       "accessory": {
         "htmlFields": [


### PR DESCRIPTION
Closes #126.

<img width="311" height="296" alt="image" src="https://github.com/user-attachments/assets/c6a2c53a-f4e8-408a-b024-15ea2e9035bd" />

TODO:
- [ ] When a new combat is created, provide UI to assign the different battlefield regions.
- [ ] Implement delayed initiative.