### PR TITLE
[#148] Allow for checks to append to existing messages.

### DIFF
--- a/code/applications/sheets/actor-sheet.mjs
+++ b/code/applications/sheets/actor-sheet.mjs
@@ -16,6 +16,7 @@ export default class RyuutamaActorSheet extends RyuutamaDocumentSheet {
       configure: RyuutamaActorSheet.#configure,
       configurePrototypeToken: RyuutamaActorSheet.#configurePrototypeToken,
       renderItem: RyuutamaActorSheet.#renderItem,
+      rollAttack: RyuutamaActorSheet.#rollAttack,
       rollCheck: RyuutamaActorSheet.#rollCheck,
       toggleStatus: RyuutamaActorSheet.#toggleStatus,
     },
@@ -318,6 +319,17 @@ export default class RyuutamaActorSheet extends RyuutamaDocumentSheet {
   static #renderItem(event, target) {
     const item = this.getEmbeddedDocument(target.dataset.uuid);
     item.sheet.render({ force: true, mode: 1 });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaActorSheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #rollAttack(event, target) {
+    this.document.system.rollAttack({}, { configure: !event.shiftKey }, {});
   }
 
   /* -------------------------------------------------- */

--- a/code/data/actor/_types.mjs
+++ b/code/data/actor/_types.mjs
@@ -60,4 +60,6 @@
  *                                                      This does not include `rolls` or `content`.
  * @property {Record<string, boolean>} [rollOptions]    Options for the roll. The effect of these depends on
  *                                                      the type of check being performed.
+ * @property {string} [messageId]                       The id of a message (of type `standard`) to append to
+ *                                                      rather than create a new message. The `create` option is ignored.
  */

--- a/code/data/chat-message/parts/damage.mjs
+++ b/code/data/chat-message/parts/damage.mjs
@@ -14,6 +14,7 @@ export default class DamagePart extends MessagePart {
   /** @override */
   static ACTIONS = {
     applyDamage: DamagePart.#applyDamage,
+    rollDamage: DamagePart.#rollDamage,
   };
 
   /* -------------------------------------------------- */
@@ -53,12 +54,28 @@ export default class DamagePart extends MessagePart {
    * @param {PointerEvent} event    Initiating click event.
    * @param {HTMLElement} target    The capturing element that defined the [data-action].
    */
-  static async #applyDamage(event, target) {
+  static #applyDamage(event, target) {
     const damages = this.damages;
     const section = target.closest("[data-message-part]");
     for (const actorElement of section.querySelectorAll("damage-tray [data-actor-uuid]")) {
       const actor = fromUuidSync(actorElement.dataset.actorUuid);
       actor.system.applyDamage(damages);
     }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Roll unresolved damage.
+   * @this DamagePart
+   * @param {PointerEvent} event    Initiating click event.
+   * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static #rollDamage(event, target) {
+    const message = this.parent.parent;
+    const rollConfig = { type: "damage" };
+    const dialogConfig = { configure: !event.shiftKey };
+    const messageConfig = { messageId: message.id };
+    message.speakerActor.system.rollCheck(rollConfig, dialogConfig, messageConfig);
   }
 }

--- a/code/data/chat-message/standard.mjs
+++ b/code/data/chat-message/standard.mjs
@@ -50,6 +50,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
       rollData: this.parent.getRollData?.(),
       isWhisper: this.parent.whisper.length,
       whisperTo: this.parent.whisper.map(u => game.users.get(u)?.name).filterJoin(", "),
+      canUpdate: this.parent.canUserModify(game.user, "update"),
     };
 
     const element = this.#renderFrame(options);

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -139,7 +139,7 @@ export default class PhysicalData extends BaseData {
     switch (type) {
       case "damage":
         if (this.modifiers.has("mythril")) options.add("mythril");
-        if (this.modiifers.has("orichalcum")) options.add("orichalcum");
+        if (this.modifiers.has("orichalcum")) options.add("orichalcum");
         break;
     }
     return options;

--- a/lang/en.json
+++ b/lang/en.json
@@ -129,8 +129,7 @@
       },
       "HP": "HP",
       "MP": "MP",
-      "rollAccuracy": "Roll Accuracy",
-      "rollDamage": "Roll Damage",
+      "rollAttack": "Roll Attack",
       "rollCheck": "Roll Check",
       "condition": "Condition",
       "capacityPenalty": "{penalty} penalty on all checks",
@@ -269,7 +268,8 @@
       "DAMAGE": {
         "FIELDS": {},
         "applyDamage": "Apply Damage",
-        "defaultRollFlavor": "Damage Roll"
+        "defaultRollFlavor": "Damage Roll",
+        "rollDamage": "Roll Damage"
       },
       "EFFECT": {
         "FIELDS": {},

--- a/styles/chat/shared.css
+++ b/styles/chat/shared.css
@@ -21,10 +21,10 @@
       object-fit: contain;
     }
   }
+}
 
-  + button[data-action=applyDamage],
-  + button[data-action=applyEffects],
-  + button[data-action=applyHealing] {
+.chat-message.message [data-message-part] {
+  button[data-action] {
     width: 100%;
   }
 }

--- a/templates/chat/parts/damage.hbs
+++ b/templates/chat/parts/damage.hbs
@@ -6,8 +6,17 @@
   {{#each ctx.rolls}}{{{this}}}{{/each}}
 </section>
 
+{{#if (and canUpdate (not ctx.rolls.length))}}
 <section>
-  {{#if user.isGM}}
+  <button type="button" data-action="rollDamage">
+    <i class="fa-solid fa-burst" inert></i>
+    <span>{{localize "RYUUTAMA.CHAT.DAMAGE.rollDamage"}}</span>
+  </button>
+</section>
+{{/if}}
+
+<section>
+  {{#if (and user.isGM ctx.rolls.length)}}
   <damage-tray></damage-tray>
   <button type="button" data-action="applyDamage">
     <i class="fa-solid fa-burst" inert></i>

--- a/templates/sheets/monster-sheet/attributes.hbs
+++ b/templates/sheets/monster-sheet/attributes.hbs
@@ -6,7 +6,7 @@
   {{!-- HP & MP --}}
   {{> "actor-resources"}}
 
-  {{!-- ATTACK & CHECK --}}
+  {{!-- ATTACKS & CHECK --}}
   <div class="icon-fields">
     <div class="icon-field">
       {{#if isEditable}}
@@ -15,8 +15,9 @@
       <img src="{{attackImage}}" alt="">
       {{/if}}
       <div class="attack">
-        <button type="button" data-action="rollCheck" data-check="accuracy" {{disabled (not isInteractive)}}>{{localize "RYUUTAMA.ACTOR.rollAccuracy"}}</button>
-        <button type="button" data-action="rollCheck" data-check="damage" {{disabled (not isInteractive)}}>{{localize "RYUUTAMA.ACTOR.rollDamage"}}</button>
+        <button type="button" data-action="rollAttack" {{disabled (not isInteractive)}}>
+          <span>{{localize "RYUUTAMA.ACTOR.rollAttack"}}</span>
+        </button>
       </div>
     </div>
 

--- a/templates/sheets/traveler-sheet/attributes.hbs
+++ b/templates/sheets/traveler-sheet/attributes.hbs
@@ -5,7 +5,7 @@
   {{!-- HP & MP --}}
   {{> "actor-resources"}}
 
-  {{!-- FUMBLES & EXP --}}
+  {{!-- FUMBLES --}}
   <div class="icon-fields">
     <div class="icon-field">
       <ryuutama-icon src="systems/ryuutama/assets/official/icons/check/fumble.svg"></ryuutama-icon>
@@ -23,13 +23,14 @@
     <div class="icon-field">
       <img src="{{weaponImage}}" alt="">
       <div class="attack">
-        <button type="button" data-action="rollCheck" data-check="accuracy" {{disabled (not isInteractive)}}>{{localize "RYUUTAMA.ACTOR.rollAccuracy"}}</button>
-        <button type="button" data-action="rollCheck" data-check="damage" {{disabled (not isInteractive)}}>{{localize "RYUUTAMA.ACTOR.rollDamage"}}</button>
+        <button type="button" data-action="rollAttack" {{disabled (not isInteractive)}}>
+          <span>{{localize "RYUUTAMA.ACTOR.rollAttack"}}</span>
+        </button>
       </div>
     </div>
 
     <button type="button" class="heightened" data-action="rollCheck" data-check="check" {{disabled (not isInteractive)}}>
-      <i class="fa-solid fa-burst"></i>
+      <i class="fa-solid fa-burst" inert></i>
       <span>{{localize "RYUUTAMA.ACTOR.rollCheck"}}</span>
     </button>
   </div>


### PR DESCRIPTION
Closes #148.

Replaces the two 'Roll Accuracy' and 'Roll Damage' check buttons on the actor sheets with one 'Roll Attack', which creates an Accuracy check in a new message, with an empty `part` of type `"damage"`, and amends the DamagePart to create a button to construct a damage roll if it contains none.