### PR TITLE
[#12] Allow for requesting a check when using the `[[/check]]` enricher.

### DIFF
--- a/code/data/actor/_types.mjs
+++ b/code/data/actor/_types.mjs
@@ -62,4 +62,6 @@
  *                                                      the type of check being performed.
  * @property {string} [messageId]                       The id of a message (of type `standard`) to append to
  *                                                      rather than create a new message. The `create` option is ignored.
+ * @property {string} [requestId]                       The id of a message (of type `standard`) that requested this check,
+ *                                                      and will be updated to show the result in a compact format.
  */

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -267,7 +267,27 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
       speaker: getDocumentClass("ChatMessage").getSpeaker({ actor: this.parent }),
     }, messageConfig.data ?? {}, { overwrite: false });
 
+    // Append flag for check request messages.
+    if (game.messages.get(messageConfig.requestId)) {
+      foundry.utils.setProperty(messageData, `flags.${ryuutama.id}.requestId`, messageConfig.requestId);
+    }
+
     return messageData;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create the label for a roll configuration of a check.
+   * @param {CheckRollConfig} rollConfig
+   * @returns {string}
+   */
+  static _createCheckLabel(rollConfig) {
+    const typeLabel = game.i18n.format(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
+    const subtitle = (rollConfig.type === "journey")
+      ? ryuutama.config.checkTypes.journey.subtypes[rollConfig.journeyId].label
+      : null;
+    return subtitle ? `${typeLabel} (${subtitle})` : typeLabel;
   }
 
   /* -------------------------------------------------- */

--- a/code/data/chat-message/parts/_module.mjs
+++ b/code/data/chat-message/parts/_module.mjs
@@ -3,4 +3,5 @@ export { default as CheckPart } from "./check.mjs";
 export { default as DamagePart } from "./damage.mjs";
 export { default as EffectPart } from "./effect.mjs";
 export { default as HealingPart } from "./healing.mjs";
+export { default as RequestPart } from "./request.mjs";
 export { default as RollPart } from "./roll.mjs";

--- a/code/data/chat-message/parts/base.mjs
+++ b/code/data/chat-message/parts/base.mjs
@@ -1,3 +1,7 @@
+/**
+ * @import RyuutamaChatMessage from "../../../documents/chat-message.mjs";
+ */
+
 const { ArrayField, JSONField, StringField } = foundry.data.fields;
 
 export default class MessagePart extends foundry.abstract.DataModel {
@@ -44,6 +48,7 @@ export default class MessagePart extends foundry.abstract.DataModel {
       [ryuutama.data.message.parts.DamagePart.TYPE]: ryuutama.data.message.parts.DamagePart,
       [ryuutama.data.message.parts.EffectPart.TYPE]: ryuutama.data.message.parts.EffectPart,
       [ryuutama.data.message.parts.HealingPart.TYPE]: ryuutama.data.message.parts.HealingPart,
+      [ryuutama.data.message.parts.RequestPart.TYPE]: ryuutama.data.message.parts.RequestPart,
       [ryuutama.data.message.parts.RollPart.TYPE]: ryuutama.data.message.parts.RollPart,
     });
   }
@@ -71,6 +76,16 @@ export default class MessagePart extends foundry.abstract.DataModel {
    */
   get isRoll() {
     return !!this.rolls.length;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The parent chat message.
+   * @type {RyuutamaChatMessage}
+   */
+  get message() {
+    return this.parent.parent;
   }
 
   /* -------------------------------------------------- */
@@ -110,6 +125,16 @@ export default class MessagePart extends foundry.abstract.DataModel {
       element.addEventListener("click", event => action.call(this, event, element));
     }
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform actions when a message is created with this part.
+   * @param {object} data
+   * @param {object} options
+   * @param {string} userId
+   */
+  _onCreate(data, options, userId) {}
 
   /* -------------------------------------------------- */
 

--- a/code/data/chat-message/parts/check.mjs
+++ b/code/data/chat-message/parts/check.mjs
@@ -14,4 +14,26 @@ export default class CheckPart extends MessagePart {
 
   /** @override */
   static TEMPLATE = "systems/ryuutama/templates/chat/parts/check.hbs";
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  _onCreate(data, options, userId) {
+    const requestMessage = game.messages.get(this.message.flags[ryuutama.id]?.requestId);
+    const isUser = requestMessage && game.users
+      .getDesignatedUser(user => user.active && (user.isGM || requestMessage.isAuthor))?.isSelf;
+    if (!isUser) return;
+
+    const index = requestMessage.system.parts.findIndex(part => part.type === "request");
+    const messageData = requestMessage.toObject();
+
+    const actorUuid = this.message.speakerActor.uuid;
+    const partData = messageData.system.parts[index];
+
+    const result = { actorUuid, result: this.rolls.reduce((acc, r) => r.total, 0) };
+    if (!partData.results.findSplice(r => r.actorUuid === actorUuid, result)) {
+      partData.results.push(result);
+    }
+    requestMessage.update(messageData);
+  }
 }

--- a/code/data/chat-message/parts/request.mjs
+++ b/code/data/chat-message/parts/request.mjs
@@ -1,0 +1,106 @@
+import CreatureData from "../../actor/templates/creature.mjs";
+import MessagePart from "./base.mjs";
+
+/**
+ * @import RyuutamaActor from "../../../documents/actor.mjs";
+ */
+
+const { ArrayField, DocumentUUIDField, NumberField, ObjectField, SchemaField } = foundry.data.fields;
+
+export default class RequestPart extends MessagePart {
+  static {
+    Object.defineProperty(this, "TYPE", { value: "request" });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static ACTIONS = {
+    rollRequest: RequestPart.#rollRequest,
+    rerollRequest: RequestPart.#rerollRequest,
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static TEMPLATE = "systems/ryuutama/templates/chat/parts/request.hbs";
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      check: new SchemaField({
+        configuration: new ObjectField(),
+      }),
+      results: new ArrayField(new SchemaField({
+        actorUuid: new DocumentUUIDField({ type: "Actor" }),
+        result: new NumberField({ required: true, nullable: false }),
+      })),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareData() {
+    super.prepareData();
+    this.results = this.results.filter(r => (r.actor = fromUuidSync(r.actorUuid)));
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(context) {
+    await super._prepareContext(context);
+    context.ctx.requestText = CreatureData._createCheckLabel(this.check.configuration);
+    context.ctx.results = this.results.map(r => {
+      const result = { ...r };
+      result.disabled = !r.actor.isOwner;
+      return result;
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform an initial roll for the request.
+   * @this RequestPart
+   * @param {PointerEvent} event    Initiating click event.
+   * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static async #rollRequest(event, target) {
+    let actors;
+    if (canvas?.tokens?.controlled.length) actors = new Set(canvas.tokens.controlled.map(token => token.actor));
+    else actors = [game.user.character];
+    for (const actor of actors) if (actor) await this._rollRequest(actor, event);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform a reroll.
+   * @this RequestPart
+   * @param {PointerEvent} event    Initiating click event.
+   * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static async #rerollRequest(event, target) {
+    const actor = fromUuidSync(target.closest("[data-actor-uuid]").dataset.actorUuid);
+    this._rollRequest(actor, event);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Roll the request.
+   * @param {RyuutamaActor} actor   The actor performing the roll.
+   * @param {PointerEvent} event    Initiating click event.
+   * @returns {Promise}             A promise that resolves once the roll has been completed.
+   */
+  async _rollRequest(actor, event) {
+    const rollConfig = foundry.utils.deepClone(this.check.configuration);
+    const dialogConfig = { configure: !event.shiftKey };
+    const messageConfig = { requestId: this.message.id };
+    await actor.system.rollCheck(rollConfig, dialogConfig, messageConfig);
+  }
+}

--- a/code/data/chat-message/standard.mjs
+++ b/code/data/chat-message/standard.mjs
@@ -65,7 +65,9 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
       Object.assign(context, { part, index: i });
       await part._prepareContext(context);
       const htmlString = await handlebars.renderTemplate(part.constructor.TEMPLATE, context);
-      const html = foundry.utils.parseHTML(`<section data-message-part="${i}">${htmlString}</section>`);
+      const html = foundry.utils.parseHTML(`
+        <section data-message-part="${i}" data-message-part-type="${part.constructor.TYPE}">${htmlString}</section>`,
+      );
       part._addListeners(html, context);
       element.insertAdjacentElement("beforeend", html);
     }
@@ -95,9 +97,17 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
       whisper.length ? "whisper" : null,
       blind ? "blind" : null,
     ];
-    for (const cssClass of cssClasses) frame.classList.add(cssClass);
+    for (const cssClass of cssClasses) if (cssClass) frame.classList.add(cssClass);
     if (options.borderColor) frame.style.setProperty("border-color", options.borderColor);
     return frame;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    for (const part of this.parts) part._onCreate(data, options, userId);
   }
 
   /* -------------------------------------------------- */

--- a/code/helpers/enrichers.mjs
+++ b/code/helpers/enrichers.mjs
@@ -63,7 +63,20 @@ export default class Enrichers {
         });
 
         element.querySelector(".request")?.addEventListener("click", event => {
-          // TODO: request roll.
+          const target = event.currentTarget;
+          const application = foundry.applications.instances.get(target.closest(".application")?.id);
+          const tooltipActor = fromUuidSync(target.closest(".locked-tooltip [data-actor-uuid]")?.dataset.actorUuid);
+          let actor;
+          if (tooltipActor instanceof foundry.documents.Actor) actor = tooltipActor;
+          else if (application?.document instanceof foundry.documents.Actor) actor = application.document;
+          else if (application?.document?.actor instanceof foundry.documents.Actor) actor = application.document.actor;
+
+          const messageData = {
+            type: "standard",
+            speaker: getDocumentClass("ChatMessage").getSpeaker({ actor }),
+            system: { parts: [{ type: "request", check: { configuration: rollConfig } }] },
+          };
+          getDocumentClass("ChatMessage").create(messageData);
         });
       },
     });
@@ -258,6 +271,7 @@ export default class Enrichers {
       const request = document.createElement("A");
       request.innerHTML = "<i class=\"fa-solid fa-bullhorn\"></i>";
       request.classList.add("request");
+      request.dataset.tooltip = "RYUUTAMA.ROLL.requestRoll";
       elements.push(request);
     }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -673,15 +673,16 @@
       "consumeMental": "Consume MP",
       "consumeStamina": "Consume Stamina",
       "critical": "Critical",
+      "magic": "Magic",
+      "magicConsumeMental": "Consume MP",
+      "magicConsumeMentalHint": "The spell requires {mp} MP to cast.",
       "messageFlavor": "{type}",
       "messageFlavorAbilities": "{type} ({abilities})",
+      "requestRoll": "Request Roll",
       "situationalBonus": "Situational Bonus",
       "title": "Configure {type}: {name}",
       "unmasteredWeaponHint": "An accuracy check with an unmastered weapon costs 1 HP.",
-      "weaponBroken": "{weapon} (Broken)",
-      "magicConsumeMental": "Consume MP",
-      "magicConsumeMentalHint": "The spell requires {mp} MP to cast.",
-      "magic": "Magic"
+      "weaponBroken": "{weapon} (Broken)"
     },
 
     "SETTINGS": {

--- a/styles/chat/shared.css
+++ b/styles/chat/shared.css
@@ -1,6 +1,7 @@
 .chat-message damage-tray,
 .chat-message effect-tray,
-.chat-message healing-tray {
+.chat-message healing-tray,
+.chat-message [data-message-part-type=request] .request-results {
   display: flex;
   gap: 0.5rem;
   flex-direction: column;

--- a/templates/chat/parts/request.hbs
+++ b/templates/chat/parts/request.hbs
@@ -1,0 +1,20 @@
+{{#if part.flavor}}
+<span class="flavor">{{part.flavor}}</span>
+{{/if}}
+
+<section class="request-config">
+  <button type="button" data-action="rollRequest">
+    <i class="fa-solid fa-dice" inert></i>
+    <span>{{ctx.requestText}}</span>
+  </button>
+</section>
+
+<section class="request-results">
+  {{#each ctx.results}}
+  <div class="request-result" data-actor-uuid="{{actor.uuid}}">
+    <img src="{{actor.img}}" alt="{{actor.name}}" data-tooltip-text="{{actor.name}}">
+    <span class="result">{{result}}</span>
+    <button type="button" data-action="rerollRequest" class="icon fa-solid fa-rotate-left" {{disabled disabled}}></button>
+  </div>
+  {{/each}}
+</section>


### PR DESCRIPTION
Closes #12.

Adds a new message part type, `request`, which displays a button for rolling checks. The chat message produced by the check will be used by the author of the request (or an available GM) to display the results in a compact format.

<img width="370" height="463" alt="image" src="https://github.com/user-attachments/assets/ca8da095-a0da-4825-88a9-fbaf891aad2d" />
