### PR TITLE
[#134] Add damage roll properties to DamageRoll and display in chat

### DIFF
--- a/code/_types.mjs
+++ b/code/_types.mjs
@@ -36,6 +36,14 @@
 /* -------------------------------------------------- */
 
 /**
+ * @typedef DamageRollPropertyConfig
+ * @property {string} label   Human-readable label.
+ * @property {string} icon    Icon displayed in chat messages for this property.
+ */
+
+/* -------------------------------------------------- */
+
+/**
  * @typedef EffectExpirationTypeConfig
  * @property {string} label   Human-readable label.
  */

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -2,7 +2,7 @@ import Prelocalization from "./helpers/prelocalization.mjs";
 
 /**
  * @import {
- * AbilityScoreConfig, AnimalModifierConfig, AnimalTypeConfig, CheckTypeConfig, EffectExpirationTypeConfig, HerbTypeConfig,
+ * AbilityScoreConfig, AnimalModifierConfig, AnimalTypeConfig, CheckTypeConfig, DamageRollPropertyConfig, EffectExpirationTypeConfig, HerbTypeConfig,
  * ItemModifierConfig, ItemSizeConfig, MonsterCategoryConfig, SeasonConfig, SpellCategoryConfig, SpellActivationTypeConfig,
  * SpellDurationTypeConfig, SpellLevelConfig, SpellRangeTypeConfig, StatusEffectConfig, TerrainTypeConfig,
  * TravelerTypeConfig, UnarmedConfiguration, WeaponTypeConfig, WeatherTypeConfig
@@ -168,6 +168,35 @@ export const checkTypes = {
 };
 Prelocalization.prelocalize(checkTypes);
 Prelocalization.prelocalize(checkTypes.journey.subtypes);
+
+/* -------------------------------------------------- */
+
+/**
+ * @type {Record<string, DamageRollPropertyConfig>}
+ */
+export const damageRollProperties = {
+  damageMental: {
+    label: "RYUUTAMA.DAMAGE.PROPERTIES.damageMental",
+    icon: "systems/ryuutama/assets/icons/bolt-eye.svg",
+  },
+  ignoreArmor: {
+    label: "RYUUTAMA.DAMAGE.PROPERTIES.ignoreArmor",
+    icon: "systems/ryuutama/assets/icons/shield-disabled.svg",
+  },
+  magical: {
+    label: "RYUUTAMA.DAMAGE.PROPERTIES.magical",
+    icon: "systems/ryuutama/assets/icons/eclipse-flare.svg",
+  },
+  mythril: {
+    label: "RYUUTAMA.DAMAGE.PROPERTIES.mythril",
+    icon: "systems/ryuutama/assets/icons/fish-scales.svg",
+  },
+  orichalcum: {
+    label: "RYUUTAMA.DAMAGE.PROPERTIES.orichalcum",
+    icon: "systems/ryuutama/assets/icons/layered-armor.svg",
+  },
+};
+Prelocalization.prelocalize(damageRollProperties);
 
 /* -------------------------------------------------- */
 

--- a/code/dice/base-roll.mjs
+++ b/code/dice/base-roll.mjs
@@ -1,4 +1,9 @@
 export default class BaseRoll extends foundry.dice.Roll {
+  /** @override */
+  static CHAT_TEMPLATE = "systems/ryuutama/templates/dice/roll.hbs";
+
+  /* -------------------------------------------------- */
+
   /**
    * The type used for the `part` of a standard message.
    * @type {string}
@@ -39,5 +44,24 @@ export default class BaseRoll extends foundry.dice.Roll {
 
     if (create) return Cls.create(msg);
     return msg.toObject();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve properties to display on the roll as a tooltip.
+   * @returns {{ icon: string, tooltip: string }[]}
+   */
+  _getTooltipProperties() {
+    return [];
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareChatRenderContext(options = {}) {
+    const context = await super._prepareChatRenderContext(options);
+    context.properties = this._getTooltipProperties();
+    return context;
   }
 }

--- a/code/dice/damage-roll.mjs
+++ b/code/dice/damage-roll.mjs
@@ -11,9 +11,24 @@ export default class DamageRoll extends CheckRoll {
    * @type {Record<string, boolean>}
    */
   get damageProperties() {
-    return Object.fromEntries(
-      ["ignoreArmor", "magical", "mythril", "orichalcum", "damageMental"]
-        .map(k => [k, !!this.options[k]]),
-    );
+    const properties = {};
+    for (const property of Object.keys(ryuutama.config.damageRollProperties)) {
+      if (this.options[property]) properties[property] = true;
+    }
+    return properties;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _getTooltipProperties() {
+    const properties = [];
+    for (const [property, active] of Object.entries(this.damageProperties)) {
+      if (active) {
+        const { label: tooltip, icon } = ryuutama.config.damageRollProperties[property];
+        properties.push({ tooltip, icon });
+      }
+    }
+    return properties;
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -296,6 +296,16 @@
       }
     },
 
+    "DAMAGE": {
+      "PROPERTIES": {
+        "damageMental": "Damage MP",
+        "ignoreArmor": "Ignore Armor",
+        "magical": "Magical",
+        "mythril": "Mythril",
+        "orichalcum": "Orichalcum"
+      }
+    },
+
     "EFFECT": {
       "STATUS": {
         "FIELDS": {

--- a/styles/chat/shared.css
+++ b/styles/chat/shared.css
@@ -58,3 +58,21 @@
 .ryuutama.chat-message section[data-message-part]:not(:last-child) {
   margin-bottom: 1rem;
 }
+
+.dice-roll .dice-result .dice-total {
+  display: grid;
+  grid-template-columns: 1fr 0;
+
+  --ryuutama-color-roll-property: rgb(85, 85, 85);
+
+  .dice-properties {
+    display: flex;
+    align-items: flex-end;
+    flex-direction: row-reverse;
+
+    svg {
+      width: auto;
+      padding: 4px 2px;
+    }
+  }
+}

--- a/templates/dice/roll.hbs
+++ b/templates/dice/roll.hbs
@@ -1,0 +1,16 @@
+<div class="dice-roll" data-action="expandRoll">
+  <div class="dice-result">
+    <div class="dice-formula">{{formula}}</div>
+    {{{tooltip}}}
+    <h4 class="dice-total">
+      <span>{{total}}</span>
+      {{#if properties.length}}
+      <div class="dice-properties">
+        {{#each properties}}
+        <ryuutama-icon src="{{icon}}" data-tooltip-text="{{tooltip}}"></ryuutama-icon>
+        {{/each}}
+      </div>
+      {{/if}}
+    </h4>
+  </div>
+</div>


### PR DESCRIPTION
Overrides the base roll chat template to display SVG icons for relevant properties.

Related to #134.