### PR TITLE
[#174] Extend `MessageConfig` to allow returning numeric values for updating initiative, and reinstate `Actor#system#rollInitiative`

### DIFF
--- a/code/data/actor/_types.mjs
+++ b/code/data/actor/_types.mjs
@@ -57,12 +57,13 @@
 
 /**
  * @typedef CheckMessageConfig
- * @property {boolean} [create]                         Should a chat message be created?
- * @property {object} [data]                            Data to be used for the chat message.
- *                                                      This does not include `rolls` or `content`.
- * @property {string} [messageId]                       The id of a message (of type `standard`) to append to
- *                                                      rather than create a new message. The `create` option is ignored.
- * @property {string} [requestId]                       The id of a message (of type `standard`) that requested this check,
- *                                                      in combination with the id of the `request` part. The message will
- *                                                      be updated to show the result in a compact format.
+ * @property {boolean} [create]                 Should a chat message be created?
+ * @property {object} [data]                    Data to be used for the chat message.
+ *                                              This does not include `rolls` or `content`.
+ * @property {string} [messageId]               The id of a message (of type `standard`) to append to
+ *                                              rather than create a new message. The `create` option is ignored.
+ * @property {string} [requestId]               The id of a message (of type `standard`) that requested this check,
+ *                                              in combination with the id of the `request` part. The message will
+ *                                              be updated to show the result in a compact format.
+ * @property {boolean} [returnNumeric=false]    Return a numeric value rather than a chat message or message data.
  */

--- a/code/documents/combatant.mjs
+++ b/code/documents/combatant.mjs
@@ -15,12 +15,8 @@ export default class RyuutamaCombatant extends foundry.documents.Combatant {
       throw new Error("Ryuutama | The signature of Combatant#rollInitiative has changed and no longer allows a formula replacement.");
     }
 
-    rollConfig = foundry.utils.mergeObject({
-      type: "initiative",
-      initiative: { shield: this.actor.type === "traveler" },
-    }, rollConfig);
-    const roll = await this.actor.system.rollCheck(rollConfig, dialogConfig, messageConfig);
-    if (!roll) return this;
-    return this.update({ initiative: roll.total });
+    const result = await this.actor.system.rollInitiative(rollConfig, dialogConfig, messageConfig);
+    if (result === null) return this;
+    return this.update({ initiative: result });
   }
 }


### PR DESCRIPTION
Looks like `CreatureData#rollInitiative` got lost somewhere while `Actor#rollInitiative` still warns users to use it. This PR re-instates the method and adds a boolean property to `CheckMessageConfig` to allow it to return a simple numeric value, being the total of the evaluated roll of the check

Closes #174.