### PR TITLE
[#176] Fix placeholder in `ConditionConfig`

### DIFF
--- a/templates/apps/condition-config/form.hbs
+++ b/templates/apps/condition-config/form.hbs
@@ -1,11 +1,11 @@
 <section>
-  {{formGroup systemFields.condition.fields.value value=source.system.condition.value placeholder="0" classes="slim"}}
+  {{formGroup systemFields.condition.fields.value value=source.system.condition.value placeholder=systemFields.condition.fields.value.initial classes="slim"}}
   {{formGroup systemFields.condition.fields.immunities value=source.system.condition.immunities type="checkboxes" classes="stacked" labelAttr="name"}}
 
   {{#if (eq document.type "traveler")}}
   <fieldset>
     <legend>{{localize "RYUUTAMA.TRAVELER.shape"}}</legend>
-    {{formGroup systemFields.condition.fields.shape.fields.high value=source.system.condition.shape.high}}
+    {{formGroup systemFields.condition.fields.shape.fields.high value=source.system.condition.shape.high classes="slim"}}
   </fieldset>
   {{/if}}
 </section>

--- a/templates/sheets/monster-sheet/attributes.hbs
+++ b/templates/sheets/monster-sheet/attributes.hbs
@@ -41,7 +41,7 @@
       <div class="form-group stacked">
         <label>{{localize "RYUUTAMA.ACTOR.condition"}}</label>
         <div class="form-fields">
-          <span class="value italics">{{ifThen document.system.condition.value document.system.condition.value 0}}</span>
+          <span class="value italics">{{document.system.condition.value}}</span>
         </div>
       </div>
     </div>

--- a/templates/sheets/traveler-sheet/attributes.hbs
+++ b/templates/sheets/traveler-sheet/attributes.hbs
@@ -52,7 +52,7 @@
       <div class="form-group stacked">
         <label>{{localize "RYUUTAMA.ACTOR.condition"}}</label>
         <div class="form-fields">
-          <span class="value italics">{{ifThen document.system.condition.value document.system.condition.value 0}}</span>
+          <span class="value italics">{{document.system.condition.value}}</span>
           {{#if conditionShape.active}}
           <div class="tags center">
             {{#if conditionShape.high}}


### PR DESCRIPTION
Closes #176.

Uses the field's initial value as the placeholder, and reads directly from the document for the displayed value on the actor sheets; this also had a fallback value of '0' which was incorrect.