### PR TITLE
[#191] Split defense points and defense value

### DIFF
--- a/code/applications/apps/defense-config.mjs
+++ b/code/applications/apps/defense-config.mjs
@@ -15,4 +15,17 @@ export default class DefenseConfig extends DocumentConfig {
   get title() {
     return game.i18n.format("RYUUTAMA.DEFENSE.title", { name: this.document.name });
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.armorLabel = game.i18n.localize(
+      this.document.type === "traveler"
+        ? "RYUUTAMA.ACTOR.TRAVELER.baseDefensePoints"
+        : "RYUUTAMA.ACTOR.MONSTER.baseArmor",
+    );
+    return context;
+  }
 }

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -64,6 +64,17 @@ export default class CreatureData extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------------- */
 
   /**
+   * The actor's defense value, the target number for a chance to hit them.
+   * @type {number|null}
+   */
+  get defenseValue() {
+    const combatant = game.combat?.combatants.find(c => c.actor === this.parent);
+    return combatant ? combatant.initiative : null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Display scrolling numbers when damaged or healed.
    * @param {RyuutamaActor} actor   The actor whose HP is modified.
    * @param {number} delta          The change to HP.

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -54,6 +54,7 @@ export default class TravelerData extends CreatureData {
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "RYUUTAMA.TRAVELER",
+    "RYUUTAMA.ACTOR.TRAVELER",
   ];
 
   /* -------------------------------------------------- */
@@ -80,6 +81,15 @@ export default class TravelerData extends CreatureData {
       if (this.equipped[key]?.system.modifiers.has("cursed")) penalty++;
     }
     return penalty;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  get defenseValue() {
+    const combatant = game.combat?.combatants.find(c => c.actor === this.parent);
+    if (!combatant || (combatant.initiative === null)) return null;
+    return Math.max(combatant.initiative, this.defense.dodge);
   }
 
   /* -------------------------------------------------- */
@@ -242,11 +252,8 @@ export default class TravelerData extends CreatureData {
       + (shield?.system.isUsable ? shield.system.armor.defense : 0);
 
     this.defense.shieldDodge = this.parent.statuses.has("shieldDodge");
-    this.defense.dodge = shield?.system.isUsable ? shield.system.armor.dodge : 0;
-    this.defense.total = Math.max(
-      this.defense.armor + this.defense.gear,
-      this.defense.shieldDodge ? this.defense.dodge : 0,
-    );
+    this.defense.dodge = (shield?.system.isUsable && this.defense.shieldDodge) ? shield.system.armor.dodge : 0;
+    this.defense.total = this.defense.armor + this.defense.gear;
   }
 
   /* -------------------------------------------------- */

--- a/code/documents/combatant.mjs
+++ b/code/documents/combatant.mjs
@@ -19,4 +19,12 @@ export default class RyuutamaCombatant extends foundry.documents.Combatant {
     if (result === null) return this;
     return this.update({ initiative: result });
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    if ("initiative" in changed) this.actor?.render(false, { renderContext: "updateCombatant" });
+  }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -81,6 +81,15 @@
       "RYUUJIN": {
         "FIELDS": {}
       },
+      "MONSTER": {
+        "FIELDS": {},
+        "baseArmor": "Base Armor"
+      },
+      "TRAVELER": {
+        "FIELDS": {},
+        "defensePoints": "Defense Points",
+        "baseDefensePoints": "Base Defense Points"
+      },
 
       "TABS": {
         "attributes": "Attributes",
@@ -127,22 +136,23 @@
         "season": "Season: {season}",
         "type": "Type: {type}"
       },
+      "activeEffects": "Active",
+      "armor": "Armor",
+      "capacityPenalty": "{penalty} penalty on all checks",
+      "condition": "Condition",
+      "defenseValue": "Defense Value",
+      "description": "Description",
+      "disabledEffects": "Inactive",
       "HP": "HP",
+      "incantationSpells": "Incantation Spells",
+      "magical": "Magical",
       "MP": "MP",
+      "physical": "Physical",
       "rollAttack": "Roll Attack",
       "rollCheck": "Roll Check",
-      "condition": "Condition",
-      "capacityPenalty": "{penalty} penalty on all checks",
+      "seasonalSpells": "Seasonal Spells",
       "statusImmune": "Immune",
-      "statusSuppressed": "Suppressed ({strength})",
-      "armor": "Armor",
-      "physical": "Physical",
-      "magical": "Magical",
-      "disabledEffects": "Inactive",
-      "activeEffects": "Active",
-      "description": "Description",
-      "incantationSpells": "Incantation Spells",
-      "seasonalSpells": "Seasonal Spells"
+      "statusSuppressed": "Suppressed ({strength})"
     },
     "CREATURE": {
       "FIELDS": {
@@ -150,7 +160,6 @@
         "condition.shape.high.hint": "This ability has its die increased by 1 size (to a maximum of 12) when the actor's Condition is 10 or higher.",
         "condition.shape.high.label": "Tip-Top Shape",
         "condition.value.label": "Current Condition",
-        "defense.armor.label": "Base Armor",
         "defense.modifiers.magical.label": "Magical",
         "defense.modifiers.physical.label": "Physical",
         "resources.mental.bonuses.flat.hint": "This bonus is added to the maximum MP after all other modifiers.",

--- a/templates/apps/defense-config/form.hbs
+++ b/templates/apps/defense-config/form.hbs
@@ -1,5 +1,5 @@
 <section>
-  {{formGroup systemFields.defense.fields.armor value=source.system.defense.armor classes="slim" placeholder="0"}}
+  {{formGroup systemFields.defense.fields.armor value=source.system.defense.armor classes="slim" placeholder="0" label=armorLabel}}
 
   <fieldset>
     <legend>{{localize "RYUUTAMA.DEFENSE.modifiers"}}</legend>

--- a/templates/sheets/shared/defense.hbs
+++ b/templates/sheets/shared/defense.hbs
@@ -5,7 +5,7 @@
   <ryuutama src=""></ryuutama>
   {{/if}}
   <div class="form-group stacked">
-    <label>{{localize "RYUUTAMA.ACTOR.armor"}}</label>
+    <label>{{localize (ifThen (eq document.type "traveler") "RYUUTAMA.ACTOR.TRAVELER.defensePoints" "RYUUTAMA.ACTOR.armor")}}</label>
     <div class="form-fields">
       <span class="value italics">{{document.system.defense.total}}</span>
       {{#if armor.hasTags}}
@@ -18,6 +18,16 @@
         {{/if}}
       </div>
       {{/if}}
+    </div>
+  </div>
+</div>
+
+<div class="icon-field">
+  <ryuutama src=""></ryuutama>
+  <div class="form-group stacked">
+    <label>{{localize "RYUUTAMA.ACTOR.defenseValue"}}</label>
+    <div class="form-fields">
+      <span class="value italics">{{ifThen document.system.defenseValue document.system.defenseValue "-"}}</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adjusts labels for defense and displays 'defense value' on actor sheets. Since this is derived from combatant initiative and shields, it is a getter and not calculated during data prep. When a combatant is updated, its associated actor is re-rendered.

Closes #191.