### PR TITLE
[#38] Create 'actions' model for items

### DIFF
--- a/code/_types.mjs
+++ b/code/_types.mjs
@@ -37,8 +37,10 @@
 
 /**
  * @typedef DamageRollPropertyConfig
- * @property {string} label   Human-readable label.
- * @property {string} icon    Icon displayed in chat messages for this property.
+ * @property {string} label       Human-readable label.
+ * @property {string} icon        Icon displayed in chat messages for this property.
+ * @property {boolean} [hidden]   Whether damage roll derive this property from the item,
+ *                                and so does not show this on the item sheet for configuration.
  */
 
 /* -------------------------------------------------- */

--- a/code/applications/sheets/actor-sheet.mjs
+++ b/code/applications/sheets/actor-sheet.mjs
@@ -239,6 +239,18 @@ export default class RyuutamaActorSheet extends RyuutamaDocumentSheet {
           this.document.setFlag(ryuutama.id, "specialAbility", item.id);
         },
       },
+      {
+        group: "system",
+        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.castSpell",
+        icon: "fa-solid fa-fw fa-book",
+        condition: target => {
+          const item = getItem(target);
+          return (typeof this.document.system.castSpell === "function") && (item.type === "spell");
+        },
+        callback: target => {
+          this.document.system.castSpell(getItem(target));
+        },
+      },
     ];
 
     if (game.release.generation < 14) return options.map(k => ({ ...k, icon: `<i class="${k.icon}"></i>` }));

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -186,14 +186,17 @@ export const damageRollProperties = {
   magical: {
     label: "RYUUTAMA.DAMAGE.PROPERTIES.magical",
     icon: "systems/ryuutama/assets/icons/eclipse-flare.svg",
+    hidden: true,
   },
   mythril: {
     label: "RYUUTAMA.DAMAGE.PROPERTIES.mythril",
     icon: "systems/ryuutama/assets/icons/fish-scales.svg",
+    hidden: true,
   },
   orichalcum: {
     label: "RYUUTAMA.DAMAGE.PROPERTIES.orichalcum",
     icon: "systems/ryuutama/assets/icons/layered-armor.svg",
+    hidden: true,
   },
 };
 Prelocalization.prelocalize(damageRollProperties);

--- a/code/data/_module.mjs
+++ b/code/data/_module.mjs
@@ -10,4 +10,5 @@ export * as advancement from "./advancement/_module.mjs";
 export * as fields from "./fields/_module.mjs";
 
 export { default as Ability } from "./ability.mjs";
+export { default as ActionsModel } from "./actions-model.mjs";
 export { default as PseudoDocument } from "./pseudo-document.mjs";

--- a/code/data/actions-model.mjs
+++ b/code/data/actions-model.mjs
@@ -1,0 +1,106 @@
+/**
+ * @import RyuutamaItem from "../documents/item.mjs";
+ */
+
+const { SchemaField, SetField, StringField } = foundry.data.fields;
+
+/**
+ * An embedded model for items that perform actions.
+ */
+export default class ActionsModel extends foundry.abstract.DataModel {
+  /** @override */
+  static defineSchema() {
+    return {
+      damage: new SchemaField({
+        formula: new ryuutama.data.fields.FormulaField(),
+        properties: new SetField(new StringField()),
+      }),
+      healing: new SchemaField({
+        formula: new ryuutama.data.fields.FormulaField(),
+        properties: new SetField(new StringField()),
+      }),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = [
+    "RYUUTAMA.ITEM.ACTIONS",
+  ];
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The item on which this is embedded.
+   * @type {RyuutamaItem}
+   */
+  get item() {
+    return this.parent.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Format all data to message parts.
+   * @returns {Record<string, object>}
+   */
+  toMessagePartData() {
+    const parts = [];
+
+    // Effects
+    const effects = this.toEffectsPartData();
+    if (effects) parts.push(effects);
+
+    // Damage
+    const damage = this.toDamagePartData();
+    if (damage) parts.push(damage);
+
+    // Healing
+    const healing = this.toHealingPartData();
+    if (healing) parts.push(healing);
+
+    return Object.fromEntries(parts.map(part => [foundry.utils.randomID(), part]));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Format effects to part data.
+   * @returns {object|null}
+   */
+  toEffectsPartData() {
+    return null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Format damage to part data.
+   * @returns {object|null}
+   */
+  toDamagePartData() {
+    if (!this.damage.formula) return null;
+    const partData = { type: "damage", rolls: [] };
+    const properties = this.item.system.getRollOptions("damage").union(this.damage.properties);
+    const options = Object.fromEntries(Array.from(properties).map(p => [p, true]));
+    const roll = new ryuutama.dice.DamageRoll(this.damage.formula, this.item.getRollData(), options);
+    partData.rolls.push(roll);
+    return partData;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Format healing to part data.
+   * @returns {object|null}
+   */
+  toHealingPartData() {
+    if (!this.healing.formula) return null;
+    const partData = { type: "healing", rolls: [] };
+    const options = {};
+    const roll = new ryuutama.dice.HealingRoll(this.healing.formula, this.item.getRollData(), options);
+    partData.rolls.push(roll);
+    return partData;
+  }
+}

--- a/code/data/active-effect/standard.mjs
+++ b/code/data/active-effect/standard.mjs
@@ -33,6 +33,23 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------------- */
 
   /**
+   * Is this effect prevented from affecting the actor?
+   * @type {boolean}
+   */
+  get isSuppressed() {
+    const effect = this.parent;
+
+    if (effect.parent instanceof foundry.documents.Item) {
+      const item = effect.parent;
+      return item.system.isEffectSuppressed(effect);
+    }
+
+    return false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Create data for an enriched tooltip.
    * @returns {Promise<HTMLElement[]>}
    */

--- a/code/data/chat-message/parts/base.mjs
+++ b/code/data/chat-message/parts/base.mjs
@@ -65,6 +65,7 @@ export default class MessagePart extends foundry.abstract.DataModel {
 
   /**
    * The subtype of this part.
+   * @type {string}
    */
   static TYPE = "";
 

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -1,9 +1,11 @@
+import ActionsModel from "../actions-model.mjs";
 import BaseData from "./templates/base.mjs";
 
-const { NumberField, SchemaField, StringField } = foundry.data.fields;
+const { EmbeddedDataField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * @typedef SpellData
+ * @property {ActionsModel} actions
  * @property {object} category
  * @property {string} category.value
  * @property {object} description
@@ -31,6 +33,7 @@ export default class SpellData extends BaseData {
   /** @override */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
+      actions: new EmbeddedDataField(ActionsModel),
       category: new SchemaField({
         value: new StringField({
           required: true, initial: "incantation",
@@ -127,5 +130,12 @@ export default class SpellData extends BaseData {
     context.spell.magicOptions = Object.entries(ryuutama.config.spellCategories).map(([k, v]) => {
       return { value: k, label: v.label, group: k === "incantation" ? undefined : seasonal };
     });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  isEffectSuppressed(effect) {
+    return super.isEffectSuppressed(effect);
   }
 }

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -98,4 +98,15 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
    * @returns {Promise<void>}
    */
   async _prepareSubtypeContext(sheet, context, options) {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Does this item subtype currently suppress an effect?
+   * @param {RyuutamaActiveEffect}
+   * @returns {boolean}
+   */
+  isEffectSuppressed(effect) {
+    return false;
+  }
 }

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -45,4 +45,14 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
     return { img };
   }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  getRollData() {
+    const item = { ...this };
+    const rollData = this.actor?.getRollData() ?? {};
+    rollData.item = item;
+    return rollData;
+  }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -141,12 +141,13 @@
           "enable": "Enable Effect"
         },
         "ITEM": {
-          "view": "View Item",
-          "edit": "Edit Item",
+          "assignSpecialAbility": "Special Ability",
+          "castSpell": "Cast Spell",
           "delete": "Delete Item",
+          "edit": "Edit Item",
           "equip": "Equip Item",
           "unequip": "Unequip Item",
-          "assignSpecialAbility": "Special Ability"
+          "view": "View Item"
         },
         "MISC": {
           "classTag": "Class: {name}"
@@ -387,9 +388,20 @@
         "size5": "Size 5"
       },
       "TABS": {
+        "actions": "Actions",
         "details": "Details",
         "effects": "Effects",
         "identity": "Identity"
+      },
+      "ACTIONS": {
+        "FIELDS": {
+          "damage.formula.label": "Formula",
+          "damage.properties.label": "Properties",
+          "healing.formula.label": "Formula",
+          "healing.properties.label": "Properties"
+        },
+        "damage": "Damage",
+        "healing": "Healing"
       },
       "activeEffects": "Active",
       "defenses": "Defenses",

--- a/templates/sheets/item-sheet/actions.hbs
+++ b/templates/sheets/item-sheet/actions.hbs
@@ -1,0 +1,17 @@
+<section data-tab="{{tabs.actions.id}}" class="{{tabs.actions.cssClass}}" data-group="{{tabs.actions.group}}">
+  {{#with actions}}
+  {{!-- DAMAGE --}}
+  <fieldset>
+    <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.damage"}}</legend>
+    {{formGroup fields.damage.fields.formula value=document.damage.formula disabled=@root.disabled}}
+    {{formGroup fields.damage.fields.properties value=document.damage.properties options=damageOptions disabled=@root.disabled type="checkboxes" classes="stacked"}}
+  </fieldset>
+
+  {{!-- HEALING --}}
+  <fieldset>
+    <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.healing"}}</legend>
+    {{formGroup fields.healing.fields.formula value=document.healing.formula disabled=@root.disabled}}
+    {{!-- {{formGroup fields.healing.fields.properties value=document.healing.properties options=healingOptions disabled=@root.disabled type="checkboxes" classes="stacked"}} --}}
+  </fieldset>
+  {{/with}}
+</section>


### PR DESCRIPTION
An alternative to #147, this implements a simple `ActionModel` that holds data. This data can be formatted for message parts for a `standard` chat message.

Currently only implemented on spell items, using a spell via `CreatureData#castSpell` creates a `standard` chat message with a Magic check and the spell description, plus any relevant parts from the spell depending on its actions.

This PR implements data for damage and healing.

Closes #38.