### PR TITLE
[#20] Add rudimentary party actor, sheet, and token placement

### DIFF
--- a/code/applications/sheets/actors/_module.mjs
+++ b/code/applications/sheets/actors/_module.mjs
@@ -1,3 +1,4 @@
 export { default as RyuutamaBaseActorSheet } from "./base.mjs";
 export { default as RyuutamaMonsterSheet } from "./monster.mjs";
+export { default as RyuutamaPartySheet } from "./party.mjs";
 export { default as RyuutamaTravelerSheet } from "./traveler.mjs";

--- a/code/applications/sheets/actors/base.mjs
+++ b/code/applications/sheets/actors/base.mjs
@@ -117,31 +117,6 @@ export default class RyuutamaBaseActorSheet extends RyuutamaDocumentSheet {
 
     context.collapsed = Object.fromEntries(Array.from(this.#collapsedSections).map(s => [s, true]));
 
-    // Abilities.
-    context.abilities = Object.keys(ryuutama.config.abilityScores).map(abi => {
-      return {
-        ability: abi,
-        icon: ryuutama.config.abilityScores[abi].icon,
-        label: ryuutama.config.abilityScores[abi].label,
-        value: this.document.system.abilities[abi],
-      };
-    });
-
-    // Status effects.
-    const immunities = this.document.system.condition.immunities;
-    const affected = this.document.system.condition.statuses;
-    context.statuses = Object.entries(ryuutama.config.statusEffects).map(([status, data]) => {
-      const { img, name, _id } = data;
-      const immune = immunities.has(status);
-      const effect = this.document.effects.get(_id);
-      const strength = affected[status];
-      const suppressed = !!effect && !strength;
-      return {
-        img, name, status, immune, strength, suppressed,
-        active: !!effect,
-      };
-    });
-
     // Set up search filters.
     for (const key of Object.keys(this.constructor.SEARCH)) {
       if (this.#searchFilters.get(key)) continue;

--- a/code/applications/sheets/actors/party.mjs
+++ b/code/applications/sheets/actors/party.mjs
@@ -1,0 +1,206 @@
+import RyuutamaBaseActorSheet from "./base.mjs";
+
+/**
+ * @import RyuutamaActor from "../../../documents/actor.mjs";
+ */
+
+export default class RyuutamaPartySheet extends RyuutamaBaseActorSheet {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      placeMembers: RyuutamaPartySheet.#placeMembers,
+      removeMember: RyuutamaPartySheet.#removeMember,
+      showMember: RyuutamaPartySheet.#showMember,
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    header: {
+      template: "systems/ryuutama/templates/sheets/actors/party/header.hbs",
+    },
+    navigation: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+    members: {
+      template: "systems/ryuutama/templates/sheets/actors/party/members.hbs",
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+    details: {
+      template: "systems/ryuutama/templates/sheets/actors/party/details.hbs",
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static TABS = {
+    primary: {
+      tabs: [
+        { id: "members" },
+        { id: "details" },
+      ],
+      initial: "members",
+      labelPrefix: "RYUUTAMA.ACTOR.TABS",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * External actors who re-render this application.
+   * @type {Set<RyuutamaActor>}
+   */
+  #appActors = new Set();
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    context.header = await this.#prepareHeader();
+    context.members = await this.#prepareMembers();
+    context.details = await this.#prepareDetails();
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare details context.
+   * @returns {Promise<object>}
+   */
+  async #prepareDetails() {
+    const value = this.document.system._source.description.value;
+    const enriched = await CONFIG.ux.TextEditor.enrichHTML(value, {
+      rollData: this.document.getRollData(),
+      relativeTo: this.document,
+    });
+    return {
+      isOwner: this.document.isOwner,
+      description: { value, enriched },
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare header context.
+   * @returns {Promise<object>}
+   */
+  async #prepareHeader() {
+    const { value, max } = this.document.system.members.reduce((acc, { actor }) => {
+      const { value, max } = actor.system.resources.stamina;
+      return { value: acc.value + value, max: acc.max + max };
+    }, { value: 0, max: 0 });
+    const pct = Math.floor(value / max * 100);
+    return {
+      canPlaceMembers: game.user.isGM && canvas?.ready,
+      hp: {
+        value, max,
+        pct: Math.clamp(pct, -100, 100),
+        fill: Math.abs(pct),
+        id: this.id,
+        negative: pct < 0,
+      },
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare members context.
+   * @returns {Promise<object[]>}
+   */
+  async #prepareMembers() {
+    const members = [];
+    for (const member of this.document.system.members) {
+      const ctx = { ...member };
+      const { stamina: hp, mental: mp } = member.actor.system.resources;
+      Object.assign(ctx, {
+        hp, mp,
+        rootId: [this.id, member.actor.id].join("-"),
+        canView: member.actor.testUserPermission(game.user, "OBSERVER"),
+      });
+      members.push(ctx);
+    }
+    return members;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    for (const { actor } of this.document.system.members) {
+      actor.apps[this.id] = this;
+      this.#appActors.add(actor);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onClose(options) {
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    return super._onClose(options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  async _onDropActor(event, actor) {
+    await this.document.system.addMembers([actor]);
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static async #placeMembers(event, target) {
+    const isMaximized = this.rendered && !this.minimized;
+    if (isMaximized) await this.minimize();
+    await this.document.system.placeMembers();
+    if (isMaximized) this.maximize();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #removeMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    this.document.system.removeMembers([actor]);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #showMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    actor.sheet.render({ force: true });
+  }
+}

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -199,6 +199,9 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     // Spells.
     context.spells = this.#prepareSpells(context);
 
+    // Statuses.
+    context.statuses = this.#prepareStatuses();
+
     return context;
   }
 
@@ -757,6 +760,28 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     };
 
     return { search, groups: sections };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare statuses context.
+   * @returns {object[]}
+   */
+  #prepareStatuses() {
+    const immunities = this.document.system.condition.immunities;
+    const affected = this.document.system.condition.statuses;
+    return Object.entries(ryuutama.config.statusEffects).map(([status, data]) => {
+      const { img, name, _id } = data;
+      const immune = immunities.has(status);
+      const effect = this.document.effects.get(_id);
+      const strength = affected[status];
+      const suppressed = !!effect && !strength;
+      return {
+        img, name, status, immune, strength, suppressed,
+        active: !!effect,
+      };
+    });
   }
 
   /* -------------------------------------------------- */

--- a/code/canvas/_module.mjs
+++ b/code/canvas/_module.mjs
@@ -1,1 +1,2 @@
+export * as interaction from "./interaction/_modules.mjs";
 export * as placeables from "./placeables/_module.mjs";

--- a/code/canvas/interaction/_modules.mjs
+++ b/code/canvas/interaction/_modules.mjs
@@ -1,0 +1,1 @@
+export { default as TokenPlacement } from "./token-placement.mjs";

--- a/code/canvas/interaction/token-placement.mjs
+++ b/code/canvas/interaction/token-placement.mjs
@@ -1,0 +1,294 @@
+/**
+ * @import { PrototypeToken } from "@common/data/_module.mjs";
+ * @import RyuutamaTokenDocument from "../../documents/token.mjs";
+ */
+
+/**
+ * Configuration information for a token placement operation.
+ *
+ * @typedef TokenPlacementConfiguration
+ * @property {PrototypeToken[]} tokens  Prototype token information for rendering.
+ */
+
+/**
+ * Data for token placement on the scene.
+ * @typedef PlacementData
+ * @property {PrototypeToken} prototypeToken
+ * @property {object} index
+ * @property {number} index.total     Index of the placement across all placements.
+ * @property {number} index.unique    Index of the placement across placements with the same original token.
+ * @property {number} x
+ * @property {number} y
+ * @property {number} rotation
+ */
+
+/**
+ * Class responsible for placing one or more tokens onto the scene.
+ * @param {TokenPlacementConfiguration} config  Configuration information for placement.
+ */
+export default class TokenPlacement {
+  constructor(config) {
+    this.config = config;
+  }
+
+  /* -------------------------------------------------- */
+  /*   Properties                                       */
+  /* -------------------------------------------------- */
+
+  /**
+   * Configuration information for the placements.
+   * @type {TokenPlacementConfiguration}
+   */
+  config;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Index of the token configuration currently being placed in the scene.
+   * @param {number}
+   */
+  #currentPlacement = -1;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Track the bound event handlers so they can be properly canceled later.
+   * @type {object}
+   */
+  #events;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Placements that have been generated.
+   * @type {PlacementData[]}
+   */
+  #placements;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Preview tokens. Should match 1-to-1 with placements.
+   * @type {Token[]}
+   */
+  #previews;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is the system currently being throttled to the next animation frame?
+   * @type {boolean}
+   */
+  #throttle = false;
+
+  /* -------------------------------------------------- */
+  /*   Placement                                        */
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform the placement, asking player guidance when necessary.
+   * @param {TokenPlacementConfiguration} config
+   * @returns {Promise<PlacementData[]>}
+   */
+  static place(config) {
+    const placement = new this(config);
+    return placement.place();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform the placement, asking player guidance when necessary.
+   * @returns {Promise<PlacementData[]>}
+   */
+  async place() {
+    this.#createPreviews();
+    try {
+      const placements = [];
+      let total = 0;
+      const uniqueTokens = new Map();
+      while (this.#currentPlacement < this.config.tokens.length - 1) {
+        this.#currentPlacement++;
+        const obj = canvas.tokens.preview.addChild(this.#previews[this.#currentPlacement].object);
+        await obj.draw();
+        obj.eventMode = "none";
+        const placement = await this.#requestPlacement();
+        if (placement) {
+          const actorId = placement.prototypeToken.parent.id;
+          uniqueTokens.set(actorId, (uniqueTokens.get(actorId) ?? -1) + 1);
+          placement.index = { total: total++, unique: uniqueTokens.get(actorId) };
+          placements.push(placement);
+        } else obj.clear();
+      }
+      return placements;
+    } finally {
+      this.#destroyPreviews();
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create token previews based on the prototype tokens in config.
+   */
+  #createPreviews() {
+    this.#placements = [];
+    this.#previews = [];
+    for (const prototypeToken of this.config.tokens) {
+      const tokenData = prototypeToken.toObject();
+      tokenData.sight.enabled = false;
+      tokenData._id = foundry.utils.randomID();
+      if (tokenData.randomImg) tokenData.texture.src = prototypeToken.actor.img;
+      const Cls = foundry.utils.getDocumentClass("Token");
+      const doc = new Cls(tokenData, { parent: canvas.scene });
+      this.#placements.push({ prototypeToken, x: 0, y: 0, rotation: tokenData.rotation ?? 0 });
+      this.#previews.push(doc);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Clear any previews from the scene.
+   */
+  #destroyPreviews() {
+    this.#previews.forEach(p => p.object.destroy());
+  }
+
+  /* -------------------------------------------------- */
+  /*   Event handlers                                   */
+  /* -------------------------------------------------- */
+
+  /**
+   * Activate listeners for the placement preview.
+   * @returns {Promise<PlacementData|false>}  A promise that resolves with the final placement if created,
+   *                                          or false if the placement was skipped.
+   */
+  #requestPlacement() {
+    return new Promise((resolve, reject) => {
+      this.#events = {
+        reject, resolve,
+        confirm: this.#onConfirmPlacement.bind(this),
+        move: this.#onMovePlacement.bind(this),
+        rotate: this.#onRotatePlacement.bind(this),
+        skip: this.#onSkipPlacement.bind(this),
+      };
+
+      // Activate listeners
+      canvas.stage.on("mousemove", this.#events.move);
+      canvas.stage.on("mousedown", this.#events.confirm);
+      canvas.app.view.oncontextmenu = this.#events.skip;
+      canvas.app.view.onwheel = this.#events.rotate;
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Shared code for when token placement ends by being confirmed or canceled.
+   * @param {PointerEvent} event    The initiating click event that ended the placement.
+   */
+  async #finishPlacement(event) {
+    canvas.stage.off("mousemove", this.#events.move);
+    canvas.stage.off("mousedown", this.#events.confirm);
+    canvas.app.view.oncontextmenu = null;
+    canvas.app.view.onwheel = null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Move the token preview when the mouse moves.
+   * @param {PointerEvent} event    The initiating click event.
+   */
+  #onMovePlacement(event) {
+    event.stopPropagation();
+    if (this.#throttle) return;
+    this.#throttle = true;
+    const idx = this.#currentPlacement;
+    const preview = this.#previews[idx];
+    const clone = preview.object;
+    const local = event.data.getLocalPosition(canvas.tokens);
+    local.x -= clone.w / 2;
+    local.y -= clone.h / 2;
+    const dest = !event.shiftKey ? clone.getSnappedPosition(local) : local;
+    preview.updateSource({ x: dest.x, y: dest.y });
+    this.#placements[idx].x = preview.x;
+    this.#placements[idx].y = preview.y;
+    canvas.tokens.preview.children[this.#currentPlacement]?.refresh();
+    requestAnimationFrame(() => this.#throttle = false);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Rotate the token preview by 3˚ increments when the mouse wheel is rotated.
+   * @param {PointerEvent} event    The initiating click event.
+   */
+  #onRotatePlacement(event) {
+    if (event.ctrlKey) event.preventDefault(); // Avoid zooming the browser window
+    event.stopPropagation();
+    const delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
+    const snap = event.shiftKey ? delta : 5;
+    const preview = this.#previews[this.#currentPlacement];
+    this.#placements[this.#currentPlacement].rotation += snap * Math.sign(event.deltaY);
+    preview.updateSource({ rotation: this.#placements[this.#currentPlacement].rotation });
+    canvas.tokens.preview.children[this.#currentPlacement]?.refresh();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Confirm placement when the left mouse button is clicked.
+   * @param {PointerEvent} event    The initiating click event.
+   */
+  async #onConfirmPlacement(event) {
+    await this.#finishPlacement(event);
+    this.#events.resolve(this.#placements[this.#currentPlacement]);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Skip placement when the right mouse button is clicked.
+   * @param {PointerEvent} event    The initiating click event.
+   */
+  async #onSkipPlacement(event) {
+    await this.#finishPlacement(event);
+    this.#events.resolve(false);
+  }
+
+  /* -------------------------------------------------- */
+  /*    Helpers                                         */
+  /* -------------------------------------------------- */
+
+  /**
+   * Adjust the appended number on an unlinked token to account for multiple placements.
+   * @param {RyuutamaTokenDocument|object} tokenDocument    Document or data object to adjust.
+   * @param {PlacementData} placement                       Placement data associated with this token document.
+   */
+  static adjustAppendedNumber(tokenDocument, placement) {
+    const regex = new RegExp(/\((\d+)\)$/);
+    const match = tokenDocument.name?.match(regex);
+    if (!match) return;
+    const name = tokenDocument.name.replace(regex, `(${Number(match[1]) + placement.index.unique})`);
+    if (tokenDocument instanceof foundry.documents.TokenDocument) tokenDocument.updateSource({ name });
+    else tokenDocument.name = name;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Place tokens on the current scene from placement data.
+   * @param {PlacementData[]} placements
+   * @returns {Promise<RyuutamaTokenDocument[]>}
+   */
+  static createTokens(placements) {
+    const data = placements.map(placement => {
+      const { x, y, rotation, prototypeToken } = placement;
+      const actorId = prototypeToken.actor.id;
+      return foundry.utils.mergeObject(prototypeToken.toObject(), { x, y, rotation, actorId });
+    });
+    return canvas.scene.createEmbeddedDocuments("Token", data);
+  }
+}

--- a/code/data/actor/party.mjs
+++ b/code/data/actor/party.mjs
@@ -1,7 +1,22 @@
+/**
+ * @import RyuutamaActor from "../../documents/actor.mjs";
+ * @import RyuutamaTokenDocument from "../../documents/token.mjs";
+ */
+
+const { HTMLField, SchemaField, TypedObjectField } = foundry.data.fields;
+
 export default class PartyData extends foundry.abstract.TypeDataModel {
   /** @override */
   static defineSchema() {
-    return {};
+    return {
+      description: new SchemaField({
+        value: new HTMLField(),
+      }),
+      members: new TypedObjectField(
+        new SchemaField({}),
+        { validateKey: key => foundry.data.validators.isValidId(key) },
+      ),
+    };
   }
 
   /* -------------------------------------------------- */
@@ -29,5 +44,76 @@ export default class PartyData extends foundry.abstract.TypeDataModel {
       foundry.utils.setProperty(update, "prototypeToken.disposition", CONST.TOKEN_DISPOSITIONS.FRIENDLY);
 
     if (!foundry.utils.isEmpty(update)) this.parent.updateSource(update);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    this.members = Object.entries(this.members).reduce((acc, [id, data]) => {
+      const actor = game.actors.get(id);
+      if (this.validMember(actor)) acc.set(actor.id, Object.assign(data, { actor }));
+      return acc;
+    }, new foundry.utils.Collection());
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is a given actor valid to be a member of this party?
+   * @param {RyuutamaActor} actor
+   * @returns {boolean}
+   */
+  validMember(actor) {
+    return (actor instanceof foundry.documents.Actor) && ["traveler"].includes(actor.type)
+      && !actor.inCompendium && !actor.isToken;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add members to the party.
+   * @param {RyuutamaActor[]} [actors]    The actors to add.
+   * @returns {Promise<RyuutamaActor>}    A promise that resolves to the updated party actor.
+   */
+  async addMembers(actors = []) {
+    actors = new Set(actors.filter(this.validMember)).filter(actor => !this.members.has(actor.id));
+    const ids = [...this.members.keys(), ...actors.map(a => a.id)];
+    const update = Object.entries(this.toObject().members).reduce((acc, [id, src]) => {
+      if (ids.includes(id)) acc[id] = src;
+      return acc;
+    }, {});
+    ids.forEach(id => update[id] = {});
+    await this.parent.update({ "system.==members": update });
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Remove members from the party.
+   * @param {RyuutamaActor[]} [actors]    The actors to remove.
+   * @returns {Promise<RyuutamaActor>}    A promise that resolves to the updated party actor.
+   */
+  async removeMembers(actors = []) {
+    const update = {};
+    actors.forEach(actor => {
+      if (this.validMember(actor) && this.members.has(actor.id)) update[`-=${actor.id}`] = null;
+    });
+    await this.parent.update({ "system.members": update });
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Place down the members of this party.
+   * @returns {Promise<RyuutamaTokenDocument[]>}    A promise that resolves to the created tokens.
+   */
+  async placeMembers() {
+    const config = { tokens: this.members.map(m => m.actor.prototypeToken) };
+    const data = await ryuutama.canvas.interaction.TokenPlacement.place(config);
+    return ryuutama.canvas.interaction.TokenPlacement.createTokens(data);
   }
 }

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -49,6 +49,14 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+    if (this.parent?.type === "party") return false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   _initializeSource(data = {}, options = {}) {
     if (!data.type || (data.type === "base")) data.type = "standard";
     return super._initializeSource(data, options);

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -48,6 +48,14 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+    if (this.parent?.type === "party") return false;
+  }
+
+  /* -------------------------------------------------- */
+
   /** @override */
   getRollData() {
     const item = { ...this };

--- a/code/utils/parse-input-delta.mjs
+++ b/code/utils/parse-input-delta.mjs
@@ -1,18 +1,41 @@
 /**
  * Handle a delta input for a number value from a form.
- * @param {HTMLInputElement} input    Input that contains the modified value.
- * @param {Document} target           Target document to be updated.
- * @returns {number|void}             The new value.
+ * @param {HTMLInputElement} input              Input that contains the modified value.
+ *                                              The input must have `data-name` or `name` which is a string
+ *                                              pointing directly to the numeric property or to an object
+ *                                              that contains both `value` and `max` properties.
+ * @param {foundry.abstract.Document} target    Target document to be updated.
+ * @returns {number|void}                       The new value.
  */
 export default function parseInputDelta(input, target) {
-  let value = input.value;
-  if (["+", "-"].includes(value[0])) {
-    const delta = parseFloat(value);
-    value = Number(foundry.utils.getProperty(target, input.dataset.name ?? input.name)) + delta;
+  let name = input.dataset.name ?? input.name;
+  let attr;
+  if (name.endsWith(".value")) {
+    name = name.slice(0, -".value".length);
+    attr = foundry.utils.getProperty(target, name);
+    if (!("max" in attr)) attr = attr.value;
   }
-  else if (value[0] === "=") value = Number(value.slice(1));
-  if (Number.isNaN(value)) return;
-  if (input.max) value = Math.min(value, parseInt(input.max));
-  input.value = value;
-  return value;
+
+  // This method may be running twice, eg in case of embedded item
+  // updates on an actor sheet, in which case we bail out early.
+  if (!attr) return;
+
+  const isBar = (typeof attr === "object") && ("max" in attr);
+  const isEqual = input.value.startsWith("=");
+  const isDelta = input.value.startsWith("+") || input.value.startsWith("-");
+  const current = isBar ? attr.value : attr;
+
+  let v;
+  let i = input.value;
+  if (isEqual) i = i.slice(1);
+  if (i.endsWith("%")) {
+    const p = Number(i.slice(0, -1)) / 100;
+    if (isEqual) v = attr.max * p;
+    else v = Math.abs(current) * p;
+  } else {
+    v = Number(i);
+  }
+
+  const value = isDelta ? current + v : v;
+  return input.value = Math.round(value);
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -104,7 +104,8 @@
         }
       },
       "PARTY": {
-        "FIELDS": {}
+        "FIELDS": {},
+        "placeMembers": "Place Members"
       },
       "RYUUJIN": {
         "FIELDS": {}
@@ -152,6 +153,7 @@
         "details": "Details",
         "effects": "Effects",
         "inventory": "Inventory",
+        "members": "Party Members",
         "notes": "Notes",
         "skills": "Skills",
         "spells": "Magic"
@@ -772,11 +774,12 @@
     },
 
     "SHEETS": {
-      "ActorSheet": "Ryuutama Actor Sheet",
       "CombatantSheet": "Ryuutama Combatant Sheet",
       "ItemSheet": "Ryuutama Item Sheet",
       "MonsterSheet": "Ryuutama Monster Sheet",
-      "ReferencePageSheet": "Ryuutama Reference Page Sheet"
+      "PartySheet": "Ryuutama Party Sheet",
+      "ReferencePageSheet": "Ryuutama Reference Page Sheet",
+      "TravelerSheet": "Ryuutama Traveler Sheet"
     },
 
     "SIDEBAR": {

--- a/main.mjs
+++ b/main.mjs
@@ -55,7 +55,7 @@ Hooks.once("init", () => {
   CONFIG.Actor.collection = documents.collections.RyuutamaActors;
   CONFIG.Actor.documentClass = documents.RyuutamaActor;
   CONFIG.Actor.dataModels.monster = data.actor.MonsterData;
-  // CONFIG.Actor.dataModels.party = data.actor.PartyData;
+  CONFIG.Actor.dataModels.party = data.actor.PartyData;
   // CONFIG.Actor.dataModels.ryuujin = data.actor.RyuujinData;
   CONFIG.Actor.dataModels.traveler = data.actor.TravelerData;
 
@@ -124,7 +124,11 @@ Hooks.once("init", () => {
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaTravelerSheet,
-    { label: "RYUUTAMA.SHEETS.ActorSheet", makeDefault: true, types: ["traveler"] },
+    { label: "RYUUTAMA.SHEETS.TravelerSheet", makeDefault: true, types: ["traveler"] },
+  );
+  foundry.applications.apps.DocumentSheetConfig.registerSheet(
+    foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaPartySheet,
+    { label: "RYUUTAMA.SHEETS.PartySheet", makeDefault: true, types: ["party"] },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaMonsterSheet,

--- a/styles/sheets/actors/_styles.css
+++ b/styles/sheets/actors/_styles.css
@@ -1,3 +1,4 @@
 @import url("./shared.css");
 @import url("./monster.css");
+@import url("./party.css");
 @import url("./traveler.css");

--- a/styles/sheets/actors/party.css
+++ b/styles/sheets/actors/party.css
@@ -1,0 +1,135 @@
+.application.sheet.actor.party {
+  --min-height: 300px;
+  --min-width: 600px;
+  --members-width: 250px;
+
+  &:not(.minimizing, .maximizing, .minimized) {
+    min-height: var(--min-height);
+    min-width: var(--min-width);
+  }
+
+  .window-content {
+    container-type: inline-size;
+  }
+
+  [data-application-part=header] {
+    display: grid;
+    grid-template-columns: min(30%, 15rem) min(25%, 10rem) min(30%, 15rem);
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+
+    @container (width < 800px) {
+      grid: "left avatar" "right avatar" / 15rem 10rem;
+
+      .left-controls { grid-area: left }
+      .right-controls { grid-area: right }
+      .middle-controls { grid-area: avatar }
+    }
+
+    .left-controls {
+      .title {
+        margin: 0;
+        margin-bottom: .5rem;
+        font-size: 30px;
+      }
+    }
+  }
+
+  [data-application-part=navigation] {
+    margin: 1rem 0;
+  }
+
+  [data-application-part=members] {
+    overflow: hidden;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+      height: 100%;
+    }
+
+    .member {
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: .5rem;
+      padding: .5rem;
+      position: relative;
+      border-radius: .5rem;
+      background: rgb(58 55 55 / 0.336);
+
+      .avatar {
+        img {
+          width: 100%;
+          aspect-ratio: 1;
+          overflow: hidden;
+          object-position: top center;
+          object-fit: cover;
+        }
+      }
+
+      .details {
+        margin: 0 1.5rem 0 1rem;
+        overflow: hidden;
+
+        .title {
+          display: block;
+          font-size: 18px;
+          text-wrap: nowrap;
+          overflow: hidden visible;
+          text-overflow: ellipsis;
+          font-family: var(--ryuutama-font-gothic);
+          margin-bottom: .5rem;
+        }
+
+        .resources {
+          .stamina {
+            margin-bottom: .5rem;
+          }
+        }
+      }
+
+      .controls {
+        position: absolute;
+        inset: 0 0 auto auto;
+        display: flex;
+        flex-direction: row-reverse;
+        text-align: center;
+
+        .control {
+          margin: .5rem;
+
+          .fa-solid {
+            margin: 0;
+          }
+        }
+      }
+    }
+  }
+
+  [data-application-part=details] {
+    overflow: hidden;
+    height: 100%;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-rows: 0fr 1fr;
+      height: 100%;
+    }
+
+    .inputs {
+      display: grid;
+      gap: .5rem;
+    }
+
+    prose-mirror {
+      height: 100%;
+    }
+  }
+}

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -97,9 +97,9 @@
 /* -------------------------------------------------- */
 
 @scope (.theme-dark) to (.themed) {
-  .ryuutama, &.ryuutama {
-    --ryuutama-sidebar-primary-party: var(--ryuutama-color-palevioletred);
+  --ryuutama-sidebar-primary-party: var(--ryuutama-color-palevioletred);
 
+  .ryuutama, &.ryuutama {
     --ryuutama-color-table-header: var(--ryuutama-color-darkorange);
     --ryuutama-color-table-row-odd: var(--ryuutama-color-oldlace);
     --ryuutama-color-table-row-even: var(--ryuutama-color-bisque);
@@ -152,9 +152,9 @@
 }
 
 @scope (.theme-light) to (.themed) {
-  .ryuutama, &.ryuutama {
-    --ryuutama-sidebar-primary-party: var(--ryuutama-color-tan);
+  --ryuutama-sidebar-primary-party: var(--ryuutama-color-tan);
 
+  .ryuutama, &.ryuutama {
     --ryuutama-color-table-header: var(--ryuutama-color-darkorange);
     --ryuutama-color-table-row-odd: var(--ryuutama-color-oldlace);
     --ryuutama-color-table-row-even: var(--ryuutama-color-bisque);

--- a/system.json
+++ b/system.json
@@ -73,8 +73,12 @@
     "Actor": {
       "monster": {
         "htmlFields": [
-          "description.value",
-          "description.special.value"
+          "description.value"
+        ]
+      },
+      "party": {
+        "htmlFields": [
+          "description.value"
         ]
       },
       "traveler": {

--- a/templates/sheets/actors/party/details.hbs
+++ b/templates/sheets/actors/party/details.hbs
@@ -1,0 +1,18 @@
+<section data-tab="{{tabs.details.id}}" data-group="{{tabs.details.group}}" class="{{tabs.details.cssClass}}">
+  <div class="contents">
+    <section class="inputs {{#if (or (not details.isOwner) disabled)}} hidden {{/if}}">
+      {{#if (and details.isOwner (not disabled))}}
+      {{formGroup fields.name value=source.name rootId=rootId}}
+      {{formGroup fields.img value=source.img rootId=rootId}}
+      {{/if}}
+    </section>
+
+    <section class="description">
+      {{#if disabled}}
+      {{{details.description.enriched}}}
+      {{else}}
+      {{formInput systemFields.description.fields.value value=details.description.value}}
+      {{/if}}
+    </section>
+  </div>
+</section>

--- a/templates/sheets/actors/party/header.hbs
+++ b/templates/sheets/actors/party/header.hbs
@@ -1,0 +1,17 @@
+<section>
+  <section class="left-controls">
+    <h3 class="title">{{document.name}}</h3>
+    <a data-action="placeMembers" {{disabled (not header.canPlaceMembers)}}>
+      <i class="fa-solid fa-fw fa-bullseye" inert></i>
+      <span>{{localize "RYUUTAMA.ACTOR.PARTY.placeMembers"}}</span>
+    </a>
+  </section>
+
+  <section class="middle-controls">
+    <img src="{{document.img}}" alt="{{document.name}}">
+  </section>
+
+  <section class="right-controls">
+    <progress-bar class="stamina numeric-display {{#if header.hp.negative}} negative {{/if}}" id="{{header.hp.id}}-stamina-total" data-pct="{{header.hp.fill}}" data-label="{{header.hp.pct}}%"></progress-bar>
+  </section>
+</section>

--- a/templates/sheets/actors/party/members.hbs
+++ b/templates/sheets/actors/party/members.hbs
@@ -1,0 +1,31 @@
+<section data-tab="{{tabs.members.id}}" data-group="{{tabs.members.group}}" class="{{tabs.members.cssClass}}">
+  <div class="contents">
+    {{#each members}}
+    <section class="member" data-member-id="{{actor.id}}">
+      <section class="avatar">
+        <img src="{{actor.img}}" alt="{{actor.name}}">
+      </section>
+      <section class="details">
+        <span class="title">{{actor.name}}</span>
+
+        <section class="resources">
+          <progress-bar class="stamina numeric-display {{#if hp.negative}} negative {{/if}}" id="{{rootId}}-stamina" data-pct="{{hp.pct}}" data-label="{{hp.pct}}%"></progress-bar>
+          <progress-bar class="mental numeric-display" id="{{rootId}}-mental" data-pct="{{mp.pct}}" data-label="{{mp.pct}}%"></progress-bar>
+        </section>
+      </section>
+      <section class="controls">
+        {{#if (and @root.isInteractive (not @root.disabled))}}
+        <a class="control" data-action="removeMember">
+          <i class="fa-solid fa-fw fa-trash" inert></i>
+        </a>
+        {{/if}}
+        {{#if (and @root.disabled canView)}}
+        <a class="control" data-action="showMember">
+          <i class="fa-solid fa-fw fa-magnifying-glass" inert></i>
+        </a>
+        {{/if}}
+      </section>
+    </section>
+    {{/each}}
+  </div>
+</section>


### PR DESCRIPTION
<img width="648" height="916" alt="image" src="https://github.com/user-attachments/assets/0cdf70ee-71ae-4467-a64c-126135d64058" />

- Implements a basic "Party" sheet and actor that can be used to track party progress, place tokens, and track location on eg a world map.
- Removed or moved some redundant code in the base actor sheet.
- Implemented a TokenPlacement class to help place tokens via API, picking locations on the canvas.
- Updated the `parseInputDelta` method to accept improved syntax.
- Fixed some actor sheet labels.
- The "primary party" can be assigned by right-clicking the Party actor in the Actor directory.

Follow-up Work:
- Add a button to the `CurrentHabitat` class to render the primary party.

Closes #20.