### PR TITLE
Implement various new v14 changes

### DIFF
--- a/.vscode/i18n-ally-custom-framework.yml
+++ b/.vscode/i18n-ally-custom-framework.yml
@@ -16,6 +16,7 @@ usageMatchRegex:
   # you can ignore it and use your own matching rules as well
   - "[^\\w\\d]game\\.i18n\\.localize\\(['\"`]({key})['\"`]\\)"
   - "[^\\w\\d]game\\.i18n\\.format\\(['\"`]({key})['\"`]"
+  - "_loc\\(['\"`]({key})['\"`]"
   - "[^\\w\\d]ui\\.notifications\\.info\\(['\"`]({key})['\"`],\\s{\\s*.*\\slocalize: true\\s*.*}"
   - "[^\\w\\d]ui\\.notifications\\.warn\\(['\"`]({key})['\"`],\\s{\\s*.*\\slocalize: true\\s*.*}"
   - "[^\\w\\d]ui\\.notifications\\.error\\(['\"`]({key})['\"`],\\s{\\s*.*\\slocalize: true\\s*.*}"

--- a/code/applications/api/document-sheet.mjs
+++ b/code/applications/api/document-sheet.mjs
@@ -371,7 +371,8 @@ export default class RyuutamaDocumentSheet extends HandlebarsApplicationMixin(Do
    * @returns {Promise}         Whether the drop was fully resolved, either truthy or falsy.
    */
   async _onDropFolder(event, folder) {
-    const folders = (game.release.generation < 14) && folder.inCompendium
+    // TODO: Simplify in v14 when https://github.com/foundryvtt/foundryvtt/issues/13397 is resolved.
+    const folders = folder.inCompendium
       ? [folder].concat(folder.collection.folders.filter(f => f.getParentFolders().includes(folder)))
       : [folder].concat(folder.getSubfolders(true));
     let documents = folders.flatMap(folder => folder.contents);

--- a/code/applications/api/pseudo-document-sheet.mjs
+++ b/code/applications/api/pseudo-document-sheet.mjs
@@ -85,7 +85,7 @@ export default class RyuutamaPseudoDocumentSheet extends HandlebarsApplicationMi
   /** @inheritdoc */
   get title() {
     const { documentName, name } = this.pseudoDocument;
-    return `${game.i18n.localize(`DOCUMENT.${documentName}`)}: ${name}`;
+    return `${_loc(`DOCUMENT.${documentName}`)}: ${name}`;
   }
 
   /* -------------------------------------------------- */
@@ -162,7 +162,7 @@ export default class RyuutamaPseudoDocumentSheet extends HandlebarsApplicationMi
   /** @inheritdoc */
   async _renderFrame(options) {
     const frame = await super._renderFrame(options);
-    const copyLabel = game.i18n.localize("SHEETS.CopyUuid");
+    const copyLabel = _loc("SHEETS.CopyUuid");
 
     const properties = Object.entries({
       type: "button",
@@ -306,7 +306,7 @@ export default class RyuutamaPseudoDocumentSheet extends HandlebarsApplicationMi
     const pseudo = this.pseudoDocument;
     const id = (event.button === 2) ? pseudo.id : pseudo.uuid;
     const type = (event.button === 2) ? "id" : "uuid";
-    const label = game.i18n.localize(`DOCUMENT.${pseudo.documentName}`);
+    const label = _loc(`DOCUMENT.${pseudo.documentName}`);
     game.clipboard.copyPlainText(id);
     ui.notifications.info("DOCUMENT.IdCopiedClipboard", { format: { label, type, id } });
   }

--- a/code/applications/apps/ability-config.mjs
+++ b/code/applications/apps/ability-config.mjs
@@ -30,7 +30,7 @@ export default class AbilityConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.ABILITIES.CONFIG.title", {
+    return _loc("RYUUTAMA.ABILITIES.CONFIG.title", {
       ability: ryuutama.config.abilityScores[this.ability].label,
       name: this.document.name,
     });

--- a/code/applications/apps/advancement-dialog.mjs
+++ b/code/applications/apps/advancement-dialog.mjs
@@ -95,7 +95,7 @@ export default class AdvancementDialog extends HandlebarsApplicationMixin(Applic
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.PSEUDO.ADVANCEMENT.title", {
+    return _loc("RYUUTAMA.PSEUDO.ADVANCEMENT.title", {
       name: this.actor.name,
       nth: this.options.level.ordinalString(),
     });

--- a/code/applications/apps/attack-config.mjs
+++ b/code/applications/apps/attack-config.mjs
@@ -13,7 +13,7 @@ export default class AttackConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.ATTACK.title", { name: this.document.name });
+    return _loc("RYUUTAMA.ATTACK.title", { name: this.document.name });
   }
 
   /* -------------------------------------------------- */

--- a/code/applications/apps/check-configuration-dialog.mjs
+++ b/code/applications/apps/check-configuration-dialog.mjs
@@ -100,8 +100,8 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.ROLL.title", {
-      type: game.i18n.localize(`RYUUTAMA.ROLL.TYPES.${this.#configurations.rollConfig.type}`),
+    return _loc("RYUUTAMA.ROLL.title", {
+      type: _loc(`RYUUTAMA.ROLL.TYPES.${this.#configurations.rollConfig.type}`),
       name: this.actor.name,
     });
   }
@@ -174,7 +174,7 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
       case "accuracy":
         if (this.actor.type === "traveler") {
           if (weapon && weapon.system.isUsable) context.subtitle = weapon.name;
-          else if (weapon) context.subtitle = game.i18n.format("RYUUTAMA.ROLL.weaponBroken", { weapon: weapon.name });
+          else if (weapon) context.subtitle = _loc("RYUUTAMA.ROLL.weaponBroken", { weapon: weapon.name });
           else context.subtitle = ryuutama.config.weaponUnarmedTypes.unarmed.label;
         }
         break;

--- a/code/applications/apps/condition-config.mjs
+++ b/code/applications/apps/condition-config.mjs
@@ -13,6 +13,6 @@ export default class ConditionConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.CONDITION.title", { name: this.document.name });
+    return _loc("RYUUTAMA.CONDITION.title", { name: this.document.name });
   }
 }

--- a/code/applications/apps/defense-config.mjs
+++ b/code/applications/apps/defense-config.mjs
@@ -13,7 +13,7 @@ export default class DefenseConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.DEFENSE.title", { name: this.document.name });
+    return _loc("RYUUTAMA.DEFENSE.title", { name: this.document.name });
   }
 
   /* -------------------------------------------------- */
@@ -21,7 +21,7 @@ export default class DefenseConfig extends DocumentConfig {
   /** @inheritdoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    context.armorLabel = game.i18n.localize(
+    context.armorLabel = _loc(
       this.document.type === "traveler"
         ? "RYUUTAMA.ACTOR.TRAVELER.baseDefensePoints"
         : "RYUUTAMA.ACTOR.MONSTER.baseArmor",

--- a/code/applications/apps/resource-config.mjs
+++ b/code/applications/apps/resource-config.mjs
@@ -30,8 +30,8 @@ export default class ResourceConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.RESOURCE.title", {
-      resource: game.i18n.localize(`RYUUTAMA.RESOURCE.${this.resource}`),
+    return _loc("RYUUTAMA.RESOURCE.title", {
+      resource: _loc(`RYUUTAMA.RESOURCE.${this.resource}`),
       name: this.document.name,
     });
   }

--- a/code/applications/apps/source-config.mjs
+++ b/code/applications/apps/source-config.mjs
@@ -25,7 +25,7 @@ export default class SourceConfig extends DocumentConfig {
 
   /** @override */
   get title() {
-    return game.i18n.format("RYUUTAMA.SOURCE.title", { name: this.document.name });
+    return _loc("RYUUTAMA.SOURCE.title", { name: this.document.name });
   }
 
   /* -------------------------------------------------- */

--- a/code/applications/sheets/actors/base.mjs
+++ b/code/applications/sheets/actors/base.mjs
@@ -194,26 +194,26 @@ export default class RyuutamaBaseActorSheet extends RyuutamaDocumentSheet {
     /** @type {ContextMenuEntry[]} */
     const options = [
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.view",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.view",
         icon: "fa-solid fa-fw fa-eye",
-        callback: target => getItem(target).sheet.render({ force: true, mode: 1 }),
+        onClick: target => getItem(target).sheet.render({ force: true, mode: 1 }),
       },
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.edit",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.edit",
         icon: "fa-solid fa-fw fa-edit",
-        callback: target => getItem(target).sheet.render({ force: true, mode: 0 }),
+        onClick: target => getItem(target).sheet.render({ force: true, mode: 0 }),
       },
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.delete",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.delete",
         icon: "fa-solid fa-fw fa-trash",
-        callback: target => getItem(target).deleteDialog(),
-        condition: target => this.isEditable && (getItem(target).type !== "class"),
+        onClick: target => getItem(target).deleteDialog(),
+        visible: target => this.isEditable && (getItem(target).type !== "class"),
       },
       {
         group: "system",
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.equip",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.equip",
         icon: "fa-solid fa-fw fa-shield",
-        condition: target => {
+        visible: target => {
           if (!this.isEditable || (this.document.type !== "traveler")) return false;
           const item = getItem(target);
           if ((item.type === "shield") && !this.document.system.canEquipShield) return false;
@@ -221,55 +221,53 @@ export default class RyuutamaBaseActorSheet extends RyuutamaDocumentSheet {
           const equipped = this.document.system.equipped[item.type];
           return equipped !== item;
         },
-        callback: target => {
+        onClick: target => {
           const item = getItem(target);
           this.document.update({ [`system.equipped.${item.type}`]: item.id });
         },
       },
       {
         group: "system",
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.unequip",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.unequip",
         icon: "fa-solid fa-fw fa-shield-alt",
-        condition: target => {
+        visible: target => {
           const item = getItem(target);
           return this.isEditable && (this.document.type === "traveler")
             && (this.document.system.equipped[item.type] === item);
         },
-        callback: target => {
+        onClick: target => {
           const item = getItem(target);
           this.document.update({ [`system.equipped.${item.type}`]: null });
         },
       },
       {
         group: "system",
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.assignSpecialAbility",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.assignSpecialAbility",
         icon: "fa-solid fa-fw fa-star",
-        condition: target => {
+        visible: target => {
           if (this.document.type !== "monster") return false;
           const item = getItem(target);
           const isSpecial = this.document.getFlag(ryuutama.id, "specialAbility") === item.id;
           return (item.type === "skill") && !isSpecial;
         },
-        callback: target => {
+        onClick: target => {
           const item = getItem(target);
           this.document.setFlag(ryuutama.id, "specialAbility", item.id);
         },
       },
       {
         group: "system",
-        name: "RYUUTAMA.ACTOR.CONTEXT.ITEM.castSpell",
+        label: "RYUUTAMA.ACTOR.CONTEXT.ITEM.castSpell",
         icon: "fa-solid fa-fw fa-book",
-        condition: target => {
+        visible: target => {
           const item = getItem(target);
           return (typeof this.document.system.castSpell === "function") && (item.type === "spell");
         },
-        callback: target => {
+        onClick: target => {
           this.document.system.castSpell(getItem(target));
         },
       },
     ];
-
-    if (game.release.generation < 14) return options.map(k => ({ ...k, icon: `<i class="${k.icon}"></i>` }));
     return options;
   }
 
@@ -286,31 +284,29 @@ export default class RyuutamaBaseActorSheet extends RyuutamaDocumentSheet {
     /** @type {ContextMenuEntry[]} */
     const options = [
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.edit",
+        label: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.edit",
         icon: "fa-solid fa-fw fa-edit",
-        callback: target => getItem(target).sheet.render({ force: true }),
+        onClick: target => getItem(target).sheet.render({ force: true }),
       },
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.delete",
+        label: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.delete",
         icon: "fa-solid fa-fw fa-trash",
-        callback: target => getItem(target).deleteDialog(),
-        condition: target => (getItem(target).parent === this.document) && this.isEditable,
+        onClick: target => getItem(target).deleteDialog(),
+        visible: target => (getItem(target).parent === this.document) && this.isEditable,
       },
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.disable",
+        label: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.disable",
         icon: "fa-solid fa-fw fa-times",
-        callback: target => getItem(target).update({ disabled: true }),
-        condition: target => this.isEditable && !getItem(target).disabled,
+        onClick: target => getItem(target).update({ disabled: true }),
+        visible: target => this.isEditable && !getItem(target).disabled,
       },
       {
-        name: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.enable",
+        label: "RYUUTAMA.ACTOR.CONTEXT.EFFECT.enable",
         icon: "fa-solid fa-fw fa-check",
-        callback: target => getItem(target).update({ disabled: false }),
-        condition: target => this.isEditable && getItem(target).disabled,
+        onClick: target => getItem(target).update({ disabled: false }),
+        visible: target => this.isEditable && getItem(target).disabled,
       },
     ];
-
-    if (game.release.generation < 14) return options.map(k => ({ ...k, icon: `<i class="${k.icon}"></i>` }));
     return options;
   }
 

--- a/code/applications/sheets/actors/monster.mjs
+++ b/code/applications/sheets/actors/monster.mjs
@@ -121,9 +121,9 @@ export default class RyuutamaMonsterSheet extends RyuutamaBaseActorSheet {
         img, name, status, immune, effect, strength, suppressed,
         active: strength > 0,
         label: suppressed
-          ? game.i18n.format("RYUUTAMA.ACTOR.statusSuppressed", { strength: effect.system.strength.value })
+          ? _loc("RYUUTAMA.ACTOR.statusSuppressed", { strength: effect.system.strength.value })
           : immune
-            ? game.i18n.localize("RYUUTAMA.ACTOR.statusImmune")
+            ? _loc("RYUUTAMA.ACTOR.statusImmune")
             : strength,
       };
     });
@@ -175,7 +175,7 @@ export default class RyuutamaMonsterSheet extends RyuutamaBaseActorSheet {
 
     // Level.
     let level = this.document.system.details.level;
-    level = game.i18n.format("RYUUTAMA.ACTOR.TAGS.level", { level });
+    level = _loc("RYUUTAMA.ACTOR.TAGS.level", { level });
     tags.push({ tag: level, tooltip: level });
 
     // Category.
@@ -183,14 +183,14 @@ export default class RyuutamaMonsterSheet extends RyuutamaBaseActorSheet {
       const tag = ryuutama.config.monsterCategories[this.document.system.details.category].label;
       tags.push({
         tag,
-        tooltip: game.i18n.format("RYUUTAMA.ACTOR.TAGS.category", { category: tag }),
+        tooltip: _loc("RYUUTAMA.ACTOR.TAGS.category", { category: tag }),
       });
     }
 
     // Dragonica number.
     if (this.document.system.details.dragonica) {
       const tag = `#${this.document.system.details.dragonica.paddedString(3)}`;
-      const tooltip = game.i18n.format("RYUUTAMA.ACTOR.TAGS.dragonica", { number: tag });
+      const tooltip = _loc("RYUUTAMA.ACTOR.TAGS.dragonica", { number: tag });
       tags.push({ tag, tooltip });
     }
 
@@ -198,7 +198,7 @@ export default class RyuutamaMonsterSheet extends RyuutamaBaseActorSheet {
     const label = ryuutama.config.seasons[this.document.system.environment.season]?.label;
     if (label) tags.push({
       tag: label,
-      tooltip: game.i18n.format("RYUUTAMA.ACTOR.TAGS.season", { season: label }),
+      tooltip: _loc("RYUUTAMA.ACTOR.TAGS.season", { season: label }),
     });
 
     return tags;

--- a/code/applications/sheets/actors/party.mjs
+++ b/code/applications/sheets/actors/party.mjs
@@ -155,8 +155,8 @@ export default class RyuutamaPartySheet extends RyuutamaBaseActorSheet {
     const makeTooltip = (actor, container, ration) => {
       return [
         `<p>${ration.label}</p>`,
-        `<p>${game.i18n.localize("TYPES.Item.container")}: ${container.name}</p>`,
-        `<p>${game.i18n.localize("RYUUTAMA.ACTOR.PARTY.actorOwner")}: ${actor.name}</p>`,
+        `<p>${_loc("TYPES.Item.container")}: ${container.name}</p>`,
+        `<p>${_loc("RYUUTAMA.ACTOR.PARTY.actorOwner")}: ${actor.name}</p>`,
       ].filterJoin("");
     };
 

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -234,7 +234,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     const format = key => {
       const v = modifiers[key];
       if (!v) return null;
-      return game.i18n.format(`RYUUTAMA.ACTOR.TRAVELER.damageReduction${key.capitalize()}`, {
+      return _loc(`RYUUTAMA.ACTOR.TRAVELER.damageReduction${key.capitalize()}`, {
         value: ryuutama.utils.formatNumber(v),
       });
     };
@@ -245,7 +245,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       dp: {
         value: total,
         breakdown: [
-          game.i18n.format("RYUUTAMA.ACTOR.TRAVELER.defensePoints", { value: total }),
+          _loc("RYUUTAMA.ACTOR.TRAVELER.defensePoints", { value: total }),
           format("physical"),
           format("magical"),
         ].filter(_ => _).map(s => `<p>${s}</p>`).join(""),
@@ -253,8 +253,8 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       dv: {
         value: this.document.system.defenseValue || "—",
         breakdown: [
-          game.i18n.format("RYUUTAMA.ACTOR.TRAVELER.shieldDodge", { value: this.document.system.defense.dodge }),
-          game.i18n.format("RYUUTAMA.ACTOR.TRAVELER.initiative", { value: this.document.system.combatantInitiative ?? "—" }),
+          _loc("RYUUTAMA.ACTOR.TRAVELER.shieldDodge", { value: this.document.system.defense.dodge }),
+          _loc("RYUUTAMA.ACTOR.TRAVELER.initiative", { value: this.document.system.combatantInitiative ?? "—" }),
         ].filter(_ => _).map(s => `<P>${s}</p>`).join(""),
       },
     };
@@ -284,7 +284,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       high: condition >= 10,
       low: condition <= 2,
     };
-    ctx.label = game.i18n.format(
+    ctx.label = _loc(
       ctx.high ? "RYUUTAMA.ACTOR.TRAVELER.conditionHigh" : "RYUUTAMA.ACTOR.TRAVELER.conditionLow",
       { ability: ctx.ability });
     ctx.active = ctx.high || ctx.low;
@@ -352,8 +352,8 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     };
 
     for (const s of Object.values(sections)) {
-      s.label = game.i18n.localize(s.label);
-      s.attributeLabel = game.i18n.localize(s.attributeLabel);
+      s.label = _loc(s.label);
+      s.attributeLabel = _loc(s.attributeLabel);
       s.controlWidgets = s.create && this.isInteractive ? `
       <a data-action="createEffect" data-disabled="${s.disabled}">
         <i class="fa-solid fa-fw fa-plus" inert></i>
@@ -400,7 +400,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       const item = this.document.system.equipped[type];
       equipped[type] = {
         item, type,
-        label: game.i18n.localize(`TYPES.Item.${type}`),
+        label: _loc(`TYPES.Item.${type}`),
       };
     }
     if (!this.document.system.canEquipShield) delete equipped.shield;
@@ -423,7 +423,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       button: !context.disabled && context.isInteractive && (level < 10),
       hideBar: level === 10,
       tag: level,
-      tooltip: game.i18n.format("RYUUTAMA.ACTOR.TAGS.level", { level }),
+      tooltip: _loc("RYUUTAMA.ACTOR.TAGS.level", { level }),
     };
   }
 
@@ -477,7 +477,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       if (label && iconSmall) habitats.push({
         isSVG: iconSmall.endsWith(".svg"),
         icon: iconSmall,
-        label: game.i18n.format("RYUUTAMA.ACTOR.TAGS.specialtyTerrain", { terrain: label }),
+        label: _loc("RYUUTAMA.ACTOR.TAGS.specialtyTerrain", { terrain: label }),
         dataset: { "tooltip-text": label },
       });
     }
@@ -487,7 +487,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       if (label && icon) habitats.push({
         icon,
         isSVG: icon.endsWith(".svg"),
-        label: game.i18n.format("RYUUTAMA.ACTOR.TAGS.specialtyWeather", { weather: label }),
+        label: _loc("RYUUTAMA.ACTOR.TAGS.specialtyWeather", { weather: label }),
         dataset: { "tooltip-text": label },
       });
     }
@@ -499,7 +499,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       if (!icon) continue;
       weapons.push({
         icon,
-        label: game.i18n.format("RYUUTAMA.ACTOR.TAGS.masteredWeapon", { weapon: label }),
+        label: _loc("RYUUTAMA.ACTOR.TAGS.masteredWeapon", { weapon: label }),
         isSVG: icon.endsWith(".svg"),
         dataset: { "tooltip-text": label },
       });
@@ -541,7 +541,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
         sort: CONFIG.Item.dataModels[type].metadata.sort,
         cssClass: [state === 1 ? "active" : null, state === -1 ? "inactive" : null].filterJoin(" "),
         id: "type",
-        label: game.i18n.localize(`TYPES.Item.${type}Pl`),
+        label: _loc(`TYPES.Item.${type}Pl`),
         option: type,
       };
     };
@@ -565,8 +565,8 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       return {
         sort: CONFIG.Item.dataModels[type].metadata.sort,
         durability,
-        labelPlural: game.i18n.localize(`TYPES.Item.${type}Pl`),
-        attributeLabel: durability ? game.i18n.localize("RYUUTAMA.ACTOR.durability") : null,
+        labelPlural: _loc(`TYPES.Item.${type}Pl`),
+        attributeLabel: durability ? _loc("RYUUTAMA.ACTOR.durability") : null,
         items: items.map(item => ({
           document: item,
           attribute: durability ? makeDur(item) : null,
@@ -589,7 +589,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
         const section = makeSection(type);
         if (section) groups.push(section);
       } else {
-        if (!groups.length) groups.push({ labelPlural: game.i18n.localize("DOCUMENT.Items"), items: [] });
+        if (!groups.length) groups.push({ labelPlural: _loc("DOCUMENT.Items"), items: [] });
         for (const item of this.document.items.documentsByType[type]) {
           groups[0].items.push({
             document: item,
@@ -623,7 +623,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       allowCategorizationToggle: true,
       categoryCssClass: catMode === 1 ? "boxes-stacked" : "box",
       cssClass: sortMode === "m" ? "1-9" : "a-z",
-      placeholder: game.i18n.format("SIDEBAR.Search", { types: game.i18n.localize("DOCUMENT.Items") }),
+      placeholder: _loc("SIDEBAR.Search", { types: _loc("DOCUMENT.Items") }),
       expanded: this.expandedFilters.has(key),
       options: menuOptions,
     };
@@ -651,7 +651,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
 
     if (groups.has("other")) {
       sections.push({
-        label: game.i18n.localize("RYUUTAMA.TRAVELER.otherSkills"),
+        label: _loc("RYUUTAMA.TRAVELER.otherSkills"),
         entries: groups.get("other").map(item => ({ document: item, dataset: { "item-context": "" } })),
       });
       groups.delete("other");
@@ -659,7 +659,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
 
     for (const [classItem, skills] of groups.entries()) {
       sections.unshift({
-        label: game.i18n.format("RYUUTAMA.TRAVELER.skillSectionLabel", { name: classItem.name }),
+        label: _loc("RYUUTAMA.TRAVELER.skillSectionLabel", { name: classItem.name }),
         entries: skills.map(skill => ({ document: skill, dataset: { "item-context": "" } })),
       });
     }
@@ -695,7 +695,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
         label,
         key: category,
         documents: [],
-        attributeLabel: game.i18n.localize("RYUUTAMA.ACTOR.spellLevel"),
+        attributeLabel: _loc("RYUUTAMA.ACTOR.spellLevel"),
       };
       for (const level of ["low", "mid", "high"]) {
         const spells = byLevel[level] ?? [];
@@ -754,7 +754,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       key,
       allowCategorizationToggle: false,
       cssClass: sortMode === "m" ? "1-9" : "a-z",
-      placeholder: game.i18n.format("SIDEBAR.Search", { types: game.i18n.localize("TYPES.Item.spellPl") }),
+      placeholder: _loc("SIDEBAR.Search", { types: _loc("TYPES.Item.spellPl") }),
       expanded: this.expandedFilters.has(key),
       options: menuOptions,
     };

--- a/code/applications/sheets/item-sheet.mjs
+++ b/code/applications/sheets/item-sheet.mjs
@@ -1,5 +1,9 @@
 import RyuutamaDocumentSheet from "../api/document-sheet.mjs";
 
+/**
+ * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs";
+ */
+
 export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
   /** @override */
   static DEFAULT_OPTIONS = {
@@ -175,31 +179,29 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
     /** @type {ContextMenuEntry[]} */
     const options = [
       {
-        name: "RYUUTAMA.ITEM.CONTEXT.EFFECT.edit",
+        label: "RYUUTAMA.ITEM.CONTEXT.EFFECT.edit",
         icon: "fa-solid fa-fw fa-edit",
-        callback: target => getItem(target).sheet.render({ force: true }),
+        onClick: target => getItem(target).sheet.render({ force: true }),
       },
       {
-        name: "RYUUTAMA.ITEM.CONTEXT.EFFECT.delete",
+        label: "RYUUTAMA.ITEM.CONTEXT.EFFECT.delete",
         icon: "fa-solid fa-fw fa-trash",
-        callback: target => getItem(target).deleteDialog(),
-        condition: () => this.isEditable,
+        onClick: target => getItem(target).deleteDialog(),
+        visible: () => this.isEditable,
       },
       {
-        name: "RYUUTAMA.ITEM.CONTEXT.EFFECT.disable",
+        label: "RYUUTAMA.ITEM.CONTEXT.EFFECT.disable",
         icon: "fa-solid fa-fw fa-times",
-        callback: target => getItem(target).update({ disabled: true }),
-        condition: target => this.isEditable && !getItem(target).disabled,
+        onClick: target => getItem(target).update({ disabled: true }),
+        visible: target => this.isEditable && !getItem(target).disabled,
       },
       {
-        name: "RYUUTAMA.ITEM.CONTEXT.EFFECT.enable",
+        label: "RYUUTAMA.ITEM.CONTEXT.EFFECT.enable",
         icon: "fa-solid fa-fw fa-check",
-        callback: target => getItem(target).update({ disabled: false }),
-        condition: target => this.isEditable && getItem(target).disabled,
+        onClick: target => getItem(target).update({ disabled: false }),
+        visible: target => this.isEditable && getItem(target).disabled,
       },
     ];
-
-    if (game.release.generation < 14) return options.map(k => ({ ...k, icon: `<i class="${k.icon}"></i>` }));
     return options;
   }
 

--- a/code/applications/ui/current-habitat.mjs
+++ b/code/applications/ui/current-habitat.mjs
@@ -151,11 +151,12 @@ export default class CurrentHabitat extends Application {
    * @returns {ContextMenuEntry[]}
    */
   static #createContextMenuOptions() {
+    /** @type {ContextMenuEntry[]} */
     const options = [
       {
-        name: "RYUUTAMA.HABITAT.CONTEXT.viewFullImage",
+        label: "RYUUTAMA.HABITAT.CONTEXT.viewFullImage",
         icon: "fa-solid fa-fw fa-image",
-        callback: target => {
+        onClick: target => {
           const terrain = target.dataset.terrainId;
           const { icon: src, label: title } = ryuutama.config.terrainTypes[terrain];
           const application = new foundry.applications.apps.ImagePopout({ src, window: { title } });
@@ -163,7 +164,6 @@ export default class CurrentHabitat extends Application {
         },
       },
     ];
-    if (game.release.generation < 14) options.forEach(o => o.icon = `<i class="${o.icon}"></i>`);
     return options;
   }
 

--- a/code/data/active-effect/standard.mjs
+++ b/code/data/active-effect/standard.mjs
@@ -2,10 +2,10 @@
  * @import RyuutamaActor from "../../documents/actor.mjs";
  */
 
-export default class StandardData extends foundry.abstract.TypeDataModel {
+export default class StandardData extends foundry.data.ActiveEffectTypeDataModel {
   /** @override */
   static defineSchema() {
-    return {};
+    return Object.assign(super.defineSchema(), {});
   }
 
   /* -------------------------------------------------- */

--- a/code/data/actor/party.mjs
+++ b/code/data/actor/party.mjs
@@ -91,7 +91,7 @@ export default class PartyData extends foundry.abstract.TypeDataModel {
       return acc;
     }, {});
     ids.forEach(id => update[id] = {});
-    await this.parent.update({ "system.==members": update });
+    await this.parent.update({ "system.members": _replace(update) });
     return this.parent;
   }
 
@@ -105,7 +105,7 @@ export default class PartyData extends foundry.abstract.TypeDataModel {
   async removeMembers(actors = []) {
     const update = {};
     actors.forEach(actor => {
-      if (this.validMember(actor) && this.members.has(actor.id)) update[`-=${actor.id}`] = null;
+      if (this.validMember(actor) && this.members.has(actor.id)) update[actor.id] = _del;
     });
     await this.parent.update({ "system.members": update });
     return this.parent;

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -30,10 +30,6 @@ export default class CreatureData extends BaseData {
     return Object.assign(super.defineSchema(), {
       condition: new SchemaField({
         immunities: new SetField(new StringField({ choices: () => ryuutama.config.statusEffects })),
-        rationing: new NumberField({ nullable: false, initial: 0, min: 0, integer: true }),
-        shape: new SchemaField({
-          high: new StringField({ required: true, blank: true, choices: () => ryuutama.config.abilityScores }),
-        }),
         travel: new BooleanField(),
         value: new NumberField({ nullable: false, initial: 4, integer: true, min: 2 }),
       }),
@@ -282,11 +278,11 @@ export default class CreatureData extends BaseData {
    * @returns {Promise<object>}
    */
   async _createCheckMessage(roll, rollConfig, dialogConfig, messageConfig) {
-    const type = game.i18n.localize(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
+    const type = _loc(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
     const abilities = game.i18n
       .getListFormatter()
       .format(rollConfig.abilities?.map(abi => ryuutama.config.abilityScores[abi].label) ?? []);
-    const flavor = game.i18n.format(
+    const flavor = _loc(
       `RYUUTAMA.ROLL.messageFlavor${rollConfig.abilities?.length ? "Abilities" : ""}`,
       { type, abilities },
     );
@@ -314,7 +310,7 @@ export default class CreatureData extends BaseData {
    * @returns {string}
    */
   static _createCheckLabel(rollConfig) {
-    const typeLabel = game.i18n.format(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
+    const typeLabel = _loc(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
     const subtitle = (rollConfig.type === "journey")
       ? ryuutama.config.checkTypes.journey.subtypes[rollConfig.journeyId].label
       : null;

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -27,9 +27,15 @@ export default class CreatureData extends BaseData {
       });
     };
 
+    const statuses = Object.keys(ryuutama.config.statusEffects).reduce((acc, s) => {
+      acc[s] = new NumberField({ persisted: false, initial: null });
+      return acc;
+    }, {});
+
     return Object.assign(super.defineSchema(), {
       condition: new SchemaField({
         immunities: new SetField(new StringField({ choices: () => ryuutama.config.statusEffects })),
+        statuses: new SchemaField(statuses, { persisted: false }),
         travel: new BooleanField(),
         value: new NumberField({ nullable: false, initial: 4, integer: true, min: 2 }),
       }),
@@ -160,14 +166,14 @@ export default class CreatureData extends BaseData {
    * Prepare condition and statuses.
    */
   #prepareStatuses() {
-    const { value: condition, immunities } = this.condition;
-    const statuses = this.condition.statuses = {};
+    const { value: condition, immunities, statuses } = this.condition;
 
     for (const [id, { _id }] of Object.entries(ryuutama.config.statusEffects)) {
       const effect = this.parent.effects.get(_id);
       const { value: strength, bypass } = effect?.system.strength ?? {};
-      if (!effect || (!bypass && (strength < condition)) || (id in statuses) || immunities.has(id)) continue;
-      statuses[id] = strength;
+      statuses[id] = (!effect || (!bypass && (strength < condition)) || immunities.has(id))
+        ? null
+        : strength;
     }
   }
 
@@ -180,7 +186,9 @@ export default class CreatureData extends BaseData {
     // In case of doubled data prep, ensure the object is entirely source data. An error is otherwise thrown.
     for (const k in this.abilities) this.abilities[k] = { ...this._source.abilities[k] };
 
-    for (const id in this.condition.statuses) {
+    const statuses = this.condition.statuses;
+    for (const id of Object.keys(ryuutama.config.statusEffects)) {
+      if (!statuses[id]) continue;
       let abilities;
       switch (id) {
         case "injury": abilities = ["dexterity"]; break;
@@ -190,7 +198,6 @@ export default class CreatureData extends BaseData {
         case "shock":
         case "sickness": abilities = ["strength", "dexterity", "intelligence", "spirit"]; break;
       }
-      if (!abilities) continue;
       for (const ability of abilities) this.schema.getField(`abilities.${ability}.value`).increase(this.parent, -1);
     }
   }

--- a/code/data/advancement/advancement.mjs
+++ b/code/data/advancement/advancement.mjs
@@ -105,8 +105,8 @@ export default class Advancement extends PseudoDocument {
   async _prepareAdvancementContext(context, options) {
     context.fields = this.schema.fields;
     context.advancement = this;
-    context.title = game.i18n.format("RYUUTAMA.PSEUDO.ADVANCEMENT.configureTitle", {
-      name: game.i18n.localize(`TYPES.Advancement.${this.type}`),
+    context.title = _loc("RYUUTAMA.PSEUDO.ADVANCEMENT.configureTitle", {
+      name: _loc(`TYPES.Advancement.${this.type}`),
     });
   }
 

--- a/code/data/advancement/habitat.mjs
+++ b/code/data/advancement/habitat.mjs
@@ -53,8 +53,8 @@ export default class HabitatAdvancement extends Advancement {
   async _prepareAdvancementContext(context, options) {
     await super._prepareAdvancementContext(context, options);
     context.typeOptions = [
-      { value: "terrain", label: game.i18n.localize("RYUUTAMA.PSEUDO.ADVANCEMENT.HABITAT.optionTerrain") },
-      { value: "weather", label: game.i18n.localize("RYUUTAMA.PSEUDO.ADVANCEMENT.HABITAT.optionWeather") },
+      { value: "terrain", label: _loc("RYUUTAMA.PSEUDO.ADVANCEMENT.HABITAT.optionTerrain") },
+      { value: "weather", label: _loc("RYUUTAMA.PSEUDO.ADVANCEMENT.HABITAT.optionWeather") },
     ];
 
     context.showTerrains = this.choice.type === "terrain";

--- a/code/data/advancement/stats.mjs
+++ b/code/data/advancement/stats.mjs
@@ -84,7 +84,7 @@ export default class StatsAdvancement extends Advancement {
   async _prepareAdvancementContext(context, options) {
     await super._prepareAdvancementContext(context, options);
     context.typeOptions = Object.entries(StatsAdvancement.STARTING_SCORES).map(([k, v]) => {
-      return { value: k, label: game.i18n.localize(v.label) };
+      return { value: k, label: _loc(v.label) };
     });
   }
 

--- a/code/data/chat-message/parts/damage.mjs
+++ b/code/data/chat-message/parts/damage.mjs
@@ -43,7 +43,7 @@ export default class DamagePart extends CheckPart {
   prepareData() {
     super.prepareData();
     this.rolls = this.rolls.filter(roll => roll instanceof ryuutama.dice.DamageRoll);
-    this.flavor ||= game.i18n.localize("RYUUTAMA.CHAT.DAMAGE.defaultRollFlavor");
+    this.flavor ||= _loc("RYUUTAMA.CHAT.DAMAGE.defaultRollFlavor");
   }
 
   /* -------------------------------------------------- */

--- a/code/data/chat-message/parts/healing.mjs
+++ b/code/data/chat-message/parts/healing.mjs
@@ -38,7 +38,7 @@ export default class HealingPart extends MessagePart {
   prepareData() {
     super.prepareData();
     this.rolls = this.rolls.filter(roll => roll instanceof ryuutama.dice.HealingRoll);
-    this.flavor ||= game.i18n.localize("RYUUTAMA.CHAT.HEALING.defaultRollFlavor");
+    this.flavor ||= _loc("RYUUTAMA.CHAT.HEALING.defaultRollFlavor");
   }
 
   /* -------------------------------------------------- */

--- a/code/data/combat/standard.mjs
+++ b/code/data/combat/standard.mjs
@@ -73,7 +73,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
   prepareDerivedData() {
     super.prepareDerivedData();
     Object.entries(this.objects).forEach(([id, o]) => {
-      o.name ||= game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder");
+      o.name ||= _loc("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder");
       Object.defineProperty(o, "id", { value: id, writable: false, enumerable: false });
     });
   }
@@ -95,7 +95,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
         {},
         {
           name: `system.objects.${id}.name`,
-          placeholder: game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder"),
+          placeholder: _loc("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder"),
           autofocus: ids[0] === id,
         },
       ));
@@ -129,7 +129,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
    * @returns {Promise<RyuutamaCombat>}
    */
   async removeObject(id) {
-    return this.parent.update({ [`system.objects.-=${id}`]: null });
+    return this.parent.update({ [`system.objects.${id}`]: _del });
   }
 
   /* -------------------------------------------------- */
@@ -163,7 +163,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
     const isGM = game.user.isGM;
 
     const header = foundry.utils.parseHTML(`<h4 class="divider">
-      <span>${game.i18n.localize("RYUUTAMA.COMBAT.STANDARD.objects")}<span>
+      <span>${_loc("RYUUTAMA.COMBAT.STANDARD.objects")}<span>
     </h4>`);
     if (isGM) {
       header.insertAdjacentHTML("beforeend",

--- a/code/data/combat/standard.mjs
+++ b/code/data/combat/standard.mjs
@@ -93,11 +93,7 @@ export default class StandardData extends foundry.abstract.TypeDataModel {
       const nameField = this.schema.getField("objects.element.name");
       content.insertAdjacentElement("beforeend", nameField.toFormGroup(
         {},
-        {
-          name: `system.objects.${id}.name`,
-          placeholder: _loc("RYUUTAMA.COMBAT.STANDARD.FIELDS.objects.element.name.placeholder"),
-          autofocus: ids[0] === id,
-        },
+        { name: `system.objects.${id}.name`, autofocus: ids[0] === id },
       ));
     }
     const configuration = await foundry.applications.api.Dialog.input({ content });

--- a/code/data/fields/ability-score-field.mjs
+++ b/code/data/fields/ability-score-field.mjs
@@ -55,7 +55,7 @@ export default class AbilityScoreField extends NumberField {
     const value = foundry.utils.getProperty(actor, path);
     const change = {
       key: this.fieldPath,
-      mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+      mode: "add",
       value: String(delta),
     };
     const final = this._applyChangeAdd(value, delta, actor, change);

--- a/code/data/fields/identifier-field.mjs
+++ b/code/data/fields/identifier-field.mjs
@@ -12,7 +12,7 @@ export default class IdentifierField extends foundry.data.fields.StringField {
   /** @override */
   _validateType(value) {
     if (!ryuutama.utils.isValidIdentifier(value)) {
-      throw new Error(game.i18n.localize("RYUUTAMA.ITEM.identifierError"));
+      throw new Error(_loc("RYUUTAMA.ITEM.identifierError"));
     }
   }
 }

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -99,7 +99,7 @@ export default class ContainerData extends BaseData {
           const { label, allowModifiers } = ryuutama.config.rationTypes[this.type];
           const m = ryuutama.config.rationModifiers[this.modifier];
           if (allowModifiers && m.prefix)
-            return game.i18n.format("RYUUTAMA.RATIONS.rationLabel", { type: label, prefix: m.label });
+            return _loc("RYUUTAMA.RATIONS.rationLabel", { type: label, prefix: m.label });
           return label;
         },
       });
@@ -162,7 +162,7 @@ export default class ContainerData extends BaseData {
    */
   async removeRation(id) {
     if (!(id in this.rations)) throw new Error(`No ration with id '${id}' exists on this container.`);
-    await this.parent.update({ [`system.rations.-=${id}`]: null });
+    await this.parent.update({ [`system.rations.${id}`]: _del });
     return this.parent;
   }
 
@@ -181,7 +181,7 @@ export default class ContainerData extends BaseData {
       throw new Error(`Container does not have ${quantity} rations of type '${type}' to remove (${ids.length}).`);
     }
     const update = {};
-    ids.forEach(id => update[`system.rations.-=${id}`] = null);
+    ids.forEach(id => update[`system.rations.${id}`] = _del);
     await this.parent.update(update);
     return this.parent;
   }

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -124,7 +124,7 @@ export default class HerbData extends BaseData {
       return details ? `${typeLabel} (${details})` : typeLabel;
     }
 
-    const levelLabel = game.i18n.localize(`RYUUTAMA.ITEM.HERB.terrainLevel${level}`);
+    const levelLabel = _loc(`RYUUTAMA.ITEM.HERB.terrainLevel${level}`);
     return details ? `${levelLabel} (${details})` : levelLabel;
   }
 
@@ -138,15 +138,15 @@ export default class HerbData extends BaseData {
     );
 
     const herbLevelOptions = Array.fromRange(5, 1).map(n => {
-      return { value: n, label: game.i18n.localize(`RYUUTAMA.ITEM.HERB.terrainLevel${n}`) };
+      return { value: n, label: _loc(`RYUUTAMA.ITEM.HERB.terrainLevel${n}`) };
     });
-    const herbTypes = [{ value: "", label: game.i18n.localize("RYUUTAMA.ITEM.HERB.anyTerrain") }];
+    const herbTypes = [{ value: "", label: _loc("RYUUTAMA.ITEM.HERB.anyTerrain") }];
     for (const k in ryuutama.config.terrainTypes) {
       const { label, level } = ryuutama.config.terrainTypes[k];
       if (level === this.terrain.level) herbTypes.push({
         label,
         value: k,
-        group: game.i18n.localize("RYUUTAMA.ITEM.HERB.specificTerrain"),
+        group: _loc("RYUUTAMA.ITEM.HERB.specificTerrain"),
       });
     }
     context.herbTypes = herbTypes;

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -91,7 +91,7 @@ export default class SpellData extends BaseData {
     super.prepareDerivedData();
 
     if (this.spell.activation.mental) {
-      this.spell.costLabel = game.i18n.format("RYUUTAMA.ITEM.SPELL.costLabel", { mp: this.spell.activation.mental });
+      this.spell.costLabel = _loc("RYUUTAMA.ITEM.SPELL.costLabel", { mp: this.spell.activation.mental });
     }
 
     this.spell.activation.label = ryuutama.config.spellActivationTypes[this.spell.activation.cast].label;
@@ -99,7 +99,7 @@ export default class SpellData extends BaseData {
     this.spell.duration.label = this.spell.duration.type === "special"
       ? this.spell.duration.custom
       : ryuutama.config.spellDurationTypes[this.spell.duration.type].units
-        ? game.i18n.format("RYUUTAMA.ITEM.SPELL.durationLabel", {
+        ? _loc("RYUUTAMA.ITEM.SPELL.durationLabel", {
           type: ryuutama.config.spellDurationTypes[this.spell.duration.type].label,
           units: this.spell.duration.value,
         })
@@ -135,7 +135,7 @@ export default class SpellData extends BaseData {
     context.spell.duration.units = !!ryuutama.config.spellDurationTypes[context.spell.duration.type]?.units;
     context.spell.duration.special = context.spell.duration.type === "special";
 
-    const seasonal = game.i18n.localize("RYUUTAMA.ITEM.SPELL.CATEGORIES.seasonal");
+    const seasonal = _loc("RYUUTAMA.ITEM.SPELL.CATEGORIES.seasonal");
     context.spell.magicOptions = Object.entries(ryuutama.config.spellCategories).map(([k, v]) => {
       return { value: k, label: v.label, group: k === "incantation" ? undefined : seasonal };
     });

--- a/code/data/pseudo-document.mjs
+++ b/code/data/pseudo-document.mjs
@@ -190,7 +190,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    */
   prepareDerivedData() {
     if (!this.name) {
-      this.name = game.i18n.localize(`TYPES.${this.documentName}.${this.type}`);
+      this.name = _loc(`TYPES.${this.documentName}.${this.type}`);
     }
   }
 
@@ -248,7 +248,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   static async createDialog(data = {}, { parent, ...operation } = {}) {
     const { createFormGroup, createSelectInput, createTextInput } = foundry.applications.fields;
     const options = Object.keys(this.documentConfig).map(type => {
-      return { value: type, label: game.i18n.localize(`TYPES.${this.documentName}.${type}`) };
+      return { value: type, label: _loc(`TYPES.${this.documentName}.${type}`) };
     });
     const content = [
       createFormGroup({
@@ -264,7 +264,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
     const result = await foundry.applications.api.Dialog.input({
       content,
       window: {
-        title: game.i18n.format("DOCUMENT.New", { type: game.i18n.localize(`DOCUMENT.${this.documentName}`) }),
+        title: _loc("DOCUMENT.New", { type: _loc(`DOCUMENT.${this.documentName}`) }),
       },
     });
     if (!result) return null;
@@ -283,7 +283,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
       throw new Error(`The pseudo-document '${this.id}' does not exist in the pseudo-document collection!`);
     }
     Object.assign(operation, { pseudo: { operation: "delete", type: this.documentName, uuid: this.uuid } });
-    const update = { [`${this.fieldPath}.-=${this.id}`]: null };
+    const update = { [`${this.fieldPath}.${this.id}`]: _del };
     await this.document.update(update, operation);
     return this;
   }
@@ -299,7 +299,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
       throw new Error(`The pseudo-document '${this.id}' does not exist in the pseudo-document collection!`);
     }
     const activityData = foundry.utils.mergeObject(this.toObject(), {
-      name: game.i18n.format("DOCUMENT.CopyOf", { name: this.name }),
+      name: _loc("DOCUMENT.CopyOf", { name: this.name }),
     });
     return this.constructor.create(activityData, { parent: this.document });
   }

--- a/code/dice/base-roll.mjs
+++ b/code/dice/base-roll.mjs
@@ -13,14 +13,13 @@ export default class BaseRoll extends foundry.dice.Roll {
   /* -------------------------------------------------- */
 
   /** @override */
-  async toMessage(messageData = {}, { rollMode, create = true } = {}) {
+  async toMessage(messageData = {}, { messageMode, rollMode, create = true } = {}) {
     // Fall back to default message creation for irrelevant rolls.
-    if (!this.constructor.PART_TYPE) return super.toMessage(messageData, { rollMode, create });
+    if (!this.constructor.PART_TYPE) return super.toMessage(messageData, { messageMode, create });
 
-    if (rollMode === "roll") rollMode = undefined;
-    rollMode ||= game.settings.get("core", "rollMode");
+    messageMode ||= game.settings.get("core", "messageMode");
 
-    if (!this._evaluated) await this.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
+    if (!this._evaluated) await this.evaluate({ allowInteractive: messageMode !== "blind" });
 
     messageData = foundry.utils.mergeObject({
       type: "standard",
@@ -40,7 +39,7 @@ export default class BaseRoll extends foundry.dice.Roll {
 
     const Cls = getDocumentClass("ChatMessage");
     const msg = new Cls(messageData);
-    msg.applyRollMode(rollMode);
+    msg.applyMode(messageMode);
 
     if (create) return Cls.create(msg);
     return msg.toObject();

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -11,7 +11,7 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
 
         const result = await foundry.applications.api.Dialog.input({
           window: {
-            title: `${game.i18n.localize("RYUUTAMA.EFFECT.STATUS.HUD_APPLY.title")}: ${effectData.name}`,
+            title: `${_loc("RYUUTAMA.EFFECT.STATUS.HUD_APPLY.title")}: ${effectData.name}`,
           },
           position: {
             width: 420,
@@ -39,7 +39,7 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
       if (change.key.startsWith("system.mastered.weapons.")) {
         const weapon = change.key.slice("system.mastered.weapons.".length);
         change.key = "system.mastered.weapons";
-        change.mode = CONST.ACTIVE_EFFECT_MODES.ADD,
+        change.mode = "add",
         change.value = weapon || "";
       }
     }
@@ -60,15 +60,5 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
   _initializeSource(data = {}, options = {}) {
     if (!data.type || (data.type === "base")) data.type = "standard";
     return super._initializeSource(data, options);
-  }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  _applyAdd(actor, change, current, delta, changes) {
-    switch (foundry.utils.getType(current)) {
-      case "Set": current.add(delta); break;
-      default: return super._applyAdd(actor, change, current, delta, changes);
-    }
   }
 }

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -17,7 +17,7 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
             width: 420,
           },
           content: [
-            fields.value.toFormGroup({ rootId }, { autofocus: true, value: 4, placeholder: "4" }).outerHTML,
+            fields.value.toFormGroup({ rootId }, { autofocus: true, value: 4 }).outerHTML,
             fields.bypass.toFormGroup({ rootId }, {}).outerHTML,
           ].join(""),
         });

--- a/code/helpers/enrichers/check.mjs
+++ b/code/helpers/enrichers/check.mjs
@@ -44,7 +44,7 @@ export async function enricher(match, options = {}) {
   if (config.subtype) wrapper.dataset.subtype = config.subtype;
   if (config.abilities.length) wrapper.dataset.abilities = config.abilities.join("|");
   else if (config.formula) wrapper.dataset.formula = config.formula;
-  anchor.dataset.tooltipText = game.i18n.localize("RYUUTAMA.ROLL.TYPES." + config.type);
+  anchor.dataset.tooltipText = _loc("RYUUTAMA.ROLL.TYPES." + config.type);
 
   const typeConfig = ryuutama.config.checkTypes[config.type];
 

--- a/code/helpers/enrichers/check.mjs
+++ b/code/helpers/enrichers/check.mjs
@@ -140,14 +140,9 @@ export function onRender(element) {
 
 /* -------------------------------------------------- */
 
-/**
- * The function that runs to interpret message contents for a check.
- * @param {string} message
- * @param {{ speaker: object, userId: string }} chatData
- */
-export function chatMessage(message, chatData) {
-  let config = message.match(chatPattern).groups.config;
-  config = ryuutama.utils.parseEnricherConfig(config);
+/** @type {ChatCommandCallback} */
+export function chatMessage(command, match, chatData, createOptions) {
+  const config = ryuutama.utils.parseEnricherConfig(match.groups.config);
   if (adjustConfig(config) === null) return;
 
   const Cls = getDocumentClass("ChatMessage");
@@ -158,7 +153,7 @@ export function chatMessage(message, chatData) {
   const rollConfig = { type, journeyId: subtype, formula, rollOptions: options };
   if (!actor && !request) {
     ui.notifications.error("RYUUTAMA.CHAT.warnNoActorFoundForCommand", { localize: true });
-    return;
+    return false;
   }
 
   if (request) {
@@ -174,6 +169,8 @@ export function chatMessage(message, chatData) {
   } else {
     actor.system.rollCheck(rollConfig);
   }
+
+  return false;
 }
 
 /* -------------------------------------------------- */

--- a/code/helpers/enrichers/damage.mjs
+++ b/code/helpers/enrichers/damage.mjs
@@ -85,14 +85,9 @@ export function onRender(element) {
 
 /* -------------------------------------------------- */
 
-/**
- * The function that runs to interpret message contents for a damage roll.
- * @param {string} message
- * @param {{ speaker: object, userId: string }} chatData
- */
-export function chatMessage(message, chatData) {
-  let config = message.match(chatPattern).groups.config;
-  config = ryuutama.utils.parseEnricherConfig(config);
+/** @type {ChatCommandCallback} */
+export function chatMessage(command, match, chatData, createOptions) {
+  const config = ryuutama.utils.parseEnricherConfig(match.groups.config);
   if (adjustConfig(config) === null) return;
 
   const Cls = getDocumentClass("ChatMessage");
@@ -100,6 +95,7 @@ export function chatMessage(message, chatData) {
   const options = Object.fromEntries(Array.from(config.properties).map(p => [p, true]));
   const roll = new ryuutama.dice.DamageRoll(config.formula, actor?.getRollData(), options);
   roll.toMessage({ speaker: chatData.speaker });
+  return false;
 }
 
 /* -------------------------------------------------- */

--- a/code/helpers/prelocalization.mjs
+++ b/code/helpers/prelocalization.mjs
@@ -43,7 +43,7 @@ export default class Prelocalization {
           console.warn(`Source attempted registered with missing data: '${short}' / '${long}'`);
           return;
         }
-        long = game.i18n.localize(long);
+        long = _loc(long);
         if (short in config) {
           console.warn(`Duplicate source attempted registered: '${short}' / '${long}'`);
           return;

--- a/code/utils/prelocalize.mjs
+++ b/code/utils/prelocalize.mjs
@@ -10,7 +10,7 @@ export default function prelocalize(record, { properties = ["label"] } = {}) {
     for (const p of properties) {
       const unlocalized = foundry.utils.getProperty(record[k], p);
       if (!unlocalized || !game.i18n.has(unlocalized)) continue;
-      foundry.utils.setProperty(record[k], p, game.i18n.localize(unlocalized));
+      foundry.utils.setProperty(record[k], p, _loc(unlocalized));
     }
   }
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -18,6 +18,8 @@ declare global {
   const fromUuid = foundry.utils.fromUuid;
   const fromUuidSync = foundry.utils.fromUuidSync;
   const getDocumentClass = foundry.utils.getDocumentClass;
+  const _del = new foundry.data.operators.ForcedDeletion();
+  const _replace = new foundry.data.operators.ForcedReplacement();
 
   namespace ui {
     let habitat: CurrentHabitat;

--- a/lang/en.json
+++ b/lang/en.json
@@ -525,9 +525,11 @@
           "category.value.label": "Type",
           "spell.activation.cast.label": "Casting Time",
           "spell.activation.mental.label": "MP Cost",
+          "spell.duration.custom.placeholder": "Special duration",
           "spell.level.label": "Spell Level",
           "spell.range.value.label": "Range",
-          "spell.target.custom.label": "Targets"
+          "spell.target.custom.label": "Targets",
+          "spell.target.custom.placeholder": "E.g. '1 person'"
         },
         "ACTIVATION": {
           "normal": "Normal Spell",
@@ -569,8 +571,6 @@
         "costLabel": "{mp} MP",
         "duration": "Duration",
         "durationLabel": "{units} {type}",
-        "specialDuration": "Special duration",
-        "targetPlaceholder": "E.g. '1 person'",
         "timing": "Spell Timing"
       },
 

--- a/main.mjs
+++ b/main.mjs
@@ -144,12 +144,12 @@ Hooks.once("init", () => {
   );
 
   // Register status effects.
-  // TODO: This becomes a Record in v14.
-  CONFIG.statusEffects = Object.entries(config.statusEffects).map(([id, { _id, img, name, hud }]) => {
-    return { id, _id, img, name, hud };
+  CONFIG.statusEffects = {};
+  Object.entries(config.statusEffects).forEach(([id, { _id, img, name, hud }]) => {
+    CONFIG.statusEffects[id] = { id, _id, img, name, hud };
   });
   Object.entries(config.specialStatusEffects).forEach(([id, effectData]) => {
-    CONFIG.statusEffects.push({ ...effectData, id });
+    CONFIG.statusEffects[id] = { id, ...effectData };
   });
   CONFIG.specialStatusEffects.DEFEATED = "defeated";
 });

--- a/main.mjs
+++ b/main.mjs
@@ -105,6 +105,13 @@ Hooks.once("init", () => {
 
   CONFIG.ux.TooltipManager = helpers.interaction.RyuutamaTooltipManager;
 
+  // Assign chat commands.
+  for (const enricher of Object.values(helpers.enrichers)) {
+    const { id, chatPattern: rgx, chatMessage: fn } = enricher;
+    if (id && (rgx instanceof RegExp) && (typeof fn === "function"))
+      CONFIG.ui.chat.CHAT_COMMANDS[id] = { rgx, fn };
+  }
+
   // Assign rolls.
   CONFIG.Dice.rolls.unshift(dice.HealingRoll);
   CONFIG.Dice.rolls.unshift(dice.DamageRoll);
@@ -197,14 +204,4 @@ Hooks.once("ready", () => {
 
 Hooks.once("renderPlayers", () => {
   ui.habitat.render({ force: true });
-});
-
-/* -------------------------------------------------- */
-
-Hooks.on("chatMessage", (chatLog, message, chatData) => {
-  for (const { chatPattern, chatMessage } of Object.values(helpers.enrichers)) {
-    if (!chatPattern?.test(message)) continue;
-    chatMessage(message, chatData);
-    return false;
-  }
 });

--- a/styles/sheets/actors/traveler.css
+++ b/styles/sheets/actors/traveler.css
@@ -624,13 +624,7 @@
     filter: drop-shadow(0 0 var(--shadow-spread, .1rem) var(--ryuutama-color-shadow-black));
   }
 
-  .controls-dropdown,
   .window-resize-handle {
-    z-index: 2;
-  }
-
-  /* The dropdown is always below the full header, can probably revisit this in v14. */
-  .controls-dropdown {
-    top: 2.5rem;
+    z-index: 1;
   }
 }

--- a/system.json
+++ b/system.json
@@ -2,11 +2,11 @@
   "id": "ryuutama",
   "title": "Ryuutama",
   "description": "A Foundry VTT implementation of the Ryuutama Natural Fantasy RPG.",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "compatibility": {
-    "minimum": "13.351",
-    "verified": "13",
-    "maximum": "13"
+    "minimum": "14.355",
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {

--- a/templates/sheets/item-sheet/spell.hbs
+++ b/templates/sheets/item-sheet/spell.hbs
@@ -13,7 +13,7 @@
     {{formGroup systemFields.spell.fields.level value=(ifThen disabled document.system.spell.level source.system.spell.level) disabled=disabled classes="slim"}}
 
     {{!-- TARGET --}}
-    {{formGroup systemFields.spell.fields.target.fields.custom value=(ifThen disabled document.system.spell.target.custom source.system.spell.target.custom) disabled=disabled placeholder=(localize "RYUUTAMA.ITEM.SPELL.targetPlaceholder")}}
+    {{formGroup systemFields.spell.fields.target.fields.custom value=(ifThen disabled document.system.spell.target.custom source.system.spell.target.custom) disabled=disabled}}
 
     {{!-- RANGE --}}
     {{formGroup systemFields.spell.fields.range.fields.value value=(ifThen disabled document.system.spell.range.value source.system.spell.range.value) disabled=disabled classes="slim"}}
@@ -39,7 +39,7 @@
       </div>
     </div>
     {{#if spell.duration.special}}
-    {{formInput systemFields.spell.fields.duration.fields.custom value=(ifThen disabled document.system.spell.duration.custom source.system.spell.duration.custom) disabled=disabled placeholder=(localize "RYUUTAMA.ITEM.SPELL.specialDuration")}}
+    {{formInput systemFields.spell.fields.duration.fields.custom value=(ifThen disabled document.system.spell.duration.custom source.system.spell.duration.custom) disabled=disabled}}
     {{/if}}
   </fieldset>
 </section>


### PR DESCRIPTION
- Manifest updated for minimum v14.
- Making use of new `_loc`, `_del`, and `_replace` global variables.
- Adjusted from deprecated `CONST.ACTIVE_EFFECT_MODES`.
- Removed unneeded `_applyAdd` which was only there to make AEs work with Sets.
- AE datamodels now inherit from the `ActiveEffectTypeDataModel`.
- Moved some fields that were instantiated in `prepareBaseData` to the datamodel with `persisted: false`.
- Moved some fields that were in `system.condition` into the Traveler model only, using `SchemaField#extendFields`.
- Removed deprecations that ended in 2.0.0.
- Adjusted assignments on init to treat `CONFIG.statusEffects` as a Record.
- Removed unneeded css that was just for the header menu dropdown.
- Adjusted assignment of chat message commands to use `ChatLog.CHAT_COMMANDS`.
- Fixed deprecations of `core.rollMode` setting and params in `Roll#toMessage`.
- Adjusted all context menu options to use `label`, `onClick`, and `visible`.
- Adjusted some placeholders for prelocalization.