### PR TITLE
[#254] Set up 'ABILITIES' in constants

### DIFF
--- a/code/applications/apps/check-configuration-dialog.mjs
+++ b/code/applications/apps/check-configuration-dialog.mjs
@@ -139,7 +139,7 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
     const context = await super._prepareContext(options);
     context.configurations = this.#configurations;
 
-    context.abilityOptions = foundry.utils.deepClone(ryuutama.config.abilityScores);
+    context.abilityOptions = ryuutama.CONST.ABILITIES._toConfig;
     const [abi1, abi2] = this.#configurations.rollConfig.abilities ?? [];
     context.abilities = { abi1, abi2 };
 

--- a/code/applications/sheets/actors/monster.mjs
+++ b/code/applications/sheets/actors/monster.mjs
@@ -99,14 +99,13 @@ export default class RyuutamaMonsterSheet extends RyuutamaBaseActorSheet {
     }
 
     // Abilities.
-    context.abilities = Object.keys(ryuutama.config.abilityScores).map(abi => {
-      return {
-        ability: abi,
-        icon: ryuutama.config.abilityScores[abi].icon,
-        label: ryuutama.config.abilityScores[abi].abbreviation,
-        value: this.document.system.abilities[abi],
-      };
-    });
+    context.abilities = Object.entries(ryuutama.CONST.ABILITIES._toConfig)
+      .map(([ability, { icon, abbreviation: label }]) => {
+        return {
+          ability, icon, label,
+          value: this.document.system.abilities[ability],
+        };
+      });
 
     // Status effects.
     const immunities = this.document.system.condition.immunities;

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -212,15 +212,13 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
    * @returns {object[]}
    */
   #prepareAbilities() {
-    const abilities = [];
-    for (const ability of Object.keys(ryuutama.config.abilityScores)) {
-      abilities.push({
-        ...ryuutama.config.abilityScores[ability],
+    return Object.entries(ryuutama.CONST.ABILITIES._toConfig).map(([ability, config]) => {
+      return {
+        ...config,
         ability,
         value: this.document.system.abilities[ability],
-      });
-    }
-    return abilities;
+      };
+    });
   }
 
   /* -------------------------------------------------- */
@@ -279,16 +277,17 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
    */
   #prepareCondition() {
     const condition = this.document.system.condition.value;
+    const high = ryuutama.config.abilityScores[this.document.system.condition.shape.high];
     const ctx = {
-      ability: ryuutama.config.abilityScores[this.document.system.condition.shape.high]?.label ?? "−",
+      ability: high.label,
       high: condition >= 10,
       low: condition <= 2,
+      abilityIcon: high.icon,
     };
-    ctx.label = _loc(
-      ctx.high ? "RYUUTAMA.ACTOR.TRAVELER.conditionHigh" : "RYUUTAMA.ACTOR.TRAVELER.conditionLow",
-      { ability: ctx.ability });
-    ctx.active = ctx.high || ctx.low;
-    if (ctx.high) ctx.abilityIcon = ryuutama.config.abilityScores[this.document.system.condition.shape.high]?.icon;
+
+    if (ctx.high) ctx.tooltip = _loc("RYUUTAMA.ACTOR.TRAVELER.conditionHigh", { ability: ctx.ability });
+    else if (ctx.low) ctx.tooltip = _loc("RYUUTAMA.ACTOR.TRAVELER.conditionLow");
+
     return ctx;
   }
 

--- a/code/constants.mjs
+++ b/code/constants.mjs
@@ -1,0 +1,32 @@
+/**
+ * Utility method to add a `_toConfig` getter to an enum
+ * prior to freezing it, allowing for easily retrieve the limited config.
+ * @param {object} obj          The enum.
+ * @param {string} configKey    The key in `ryuutama.config`.
+ */
+const toConfig = (obj, configKey) => {
+  Object.defineProperty(obj, "_toConfig", {
+    enumerable: false,
+    get() {
+      const config = ryuutama.config[configKey];
+      return Object.values(this).reduce((acc, key) => {
+        return Object.assign(acc, { [key]: config[key] });
+      }, {});
+    },
+  });
+  Object.freeze(obj);
+};
+
+/* -------------------------------------------------- */
+
+/**
+ * Ability scores, or 'stats'.
+ * @enum {string}
+ */
+export const ABILITIES = {
+  STRENGTH: "strength",
+  DEXTERITY: "dexterity",
+  INTELLIGENCE: "intelligence",
+  SPIRIT: "spirit",
+};
+toConfig(ABILITIES, "abilityScores");

--- a/code/data/actor/monster.mjs
+++ b/code/data/actor/monster.mjs
@@ -5,11 +5,15 @@ const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields
 export default class MonsterData extends CreatureData {
   /** @inheritdoc */
   static defineSchema() {
+    const abilities = Object.values(ryuutama.CONST.ABILITIES).reduce((acc, key) => {
+      acc[key] = new SchemaField({
+        value: new ryuutama.data.fields.AbilityScoreField({ restricted: false }),
+      });
+      return acc;
+    }, {});
+
     return Object.assign(super.defineSchema(), {
-      abilities: new SchemaField(Object.keys(ryuutama.config.abilityScores).reduce((acc, ability) => {
-        acc[ability] = new SchemaField({ value: new ryuutama.data.fields.AbilityScoreField({ restricted: false }) });
-        return acc;
-      }, {})),
+      abilities: new SchemaField(abilities),
       attack: new SchemaField({
         accuracy: new ryuutama.data.fields.FormulaField(),
         damage: new ryuutama.data.fields.FormulaField(),

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -11,11 +11,15 @@ const { ColorField, HTMLField, NumberField, SchemaField, SetField, StringField }
 export default class TravelerData extends CreatureData {
   /** @inheritdoc */
   static defineSchema() {
+    const abilities = Object.values(ryuutama.CONST.ABILITIES).reduce((acc, key) => {
+      acc[key] = new SchemaField({
+        value: new ryuutama.data.fields.AbilityScoreField({ restricted: true }),
+      });
+      return acc;
+    }, {});
+
     const schema = Object.assign(super.defineSchema(), {
-      abilities: new SchemaField(Object.keys(ryuutama.config.abilityScores).reduce((acc, ability) => {
-        acc[ability] = new SchemaField({ value: new ryuutama.data.fields.AbilityScoreField({ restricted: true }) });
-        return acc;
-      }, {})),
+      abilities: new SchemaField(abilities),
       advancements: new ryuutama.data.fields.PseudoDocumentCollectionField(Advancement),
       background: new SchemaField({
         appearance: new HTMLField(),
@@ -65,7 +69,12 @@ export default class TravelerData extends CreatureData {
     schema.condition.extendFields({
       rationing: new NumberField({ nullable: false, initial: 0, min: 0, integer: true }),
       shape: new SchemaField({
-        high: new StringField({ required: true, blank: true, choices: () => ryuutama.config.abilityScores }),
+        high: new StringField({
+          required: true,
+          blank: false,
+          initial: ryuutama.CONST.ABILITIES.DEXTERITY,
+          choices: ryuutama.CONST.ABILITIES._toConfig,
+        }),
       }),
     });
 

--- a/code/data/advancement/stat-increase.mjs
+++ b/code/data/advancement/stat-increase.mjs
@@ -10,7 +10,11 @@ export default class StatIncreaseAdvancement extends Advancement {
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
       choice: new SchemaField({
-        chosen: new StringField({ blank: true, required: true, choices: () => ryuutama.config.abilityScores }),
+        chosen: new StringField({
+          blank: true,
+          required: true,
+          choices: ryuutama.CONST.ABILITIES._toConfig,
+        }),
       }),
     });
   }
@@ -51,9 +55,9 @@ export default class StatIncreaseAdvancement extends Advancement {
       return base;
     };
 
-    context.abilityOptions = Object.entries(ryuutama.config.abilityScores)
-      .filter(([k, v]) => getScore(k) < 12)
-      .map(([k, v]) => ({ value: k, label: v.label }));
+    context.abilityOptions = Object.entries(ryuutama.CONST.ABILITIES._toConfig)
+      .filter(([k]) => getScore(k) < 12)
+      .map(([k, { label }]) => ({ value: k, label }));
   }
 
   /* -------------------------------------------------- */

--- a/code/data/advancement/stats.mjs
+++ b/code/data/advancement/stats.mjs
@@ -71,10 +71,10 @@ export default class StatsAdvancement extends Advancement {
   get isConfigured() {
     const type = this.choice.type;
     const set = [...StatsAdvancement.STARTING_SCORES[type].stats];
-    for (const k in ryuutama.config.abilityScores) {
-      const value = this.choice.chosen[k];
+    Object.values(ryuutama.CONST.ABILITIES).forEach(ability => {
+      const value = this.choice.chosen[ability];
       set.findSplice(v => v === value);
-    }
+    });
     return !set.length;
   }
 
@@ -93,8 +93,8 @@ export default class StatsAdvancement extends Advancement {
   /** @inheritdoc */
   async _getAdvancementResults(actor) {
     const update = {};
-    for (const k in ryuutama.config.abilityScores) {
-      update[`system.abilities.${k}.value`] = this.choice.chosen[k];
+    for (const key of Object.values(ryuutama.CONST.ABILITIES)) {
+      update[`system.abilities.${key}.value`] = this.choice.chosen[key];
     }
 
     update["system.resources.stamina.max"] = 2 * update["system.abilities.strength.value"];

--- a/code/data/item/weapon.mjs
+++ b/code/data/item/weapon.mjs
@@ -38,8 +38,8 @@ export default class WeaponData extends PhysicalData {
           new StringField({
             required: true,
             blank: false,
-            initial: "strength",
-            choices: () => ryuutama.config.abilityScores,
+            initial: ryuutama.CONST.ABILITIES.STRENGTH,
+            choices: ryuutama.CONST.ABILITIES._toConfig,
           }),
           { min: 2, max: 2, initial: ["strength", "strength"] },
         ),
@@ -50,7 +50,10 @@ export default class WeaponData extends PhysicalData {
       }),
       damage: new SchemaField({
         ability: new StringField({
-          required: true, blank: false, choices: () => ryuutama.config.abilityScores, initial: "strength",
+          required: true,
+          blank: false,
+          initial: ryuutama.CONST.ABILITIES.STRENGTH,
+          choices: ryuutama.CONST.ABILITIES._toConfig,
         }),
         bonus: new NumberField({ nullable: true, integer: true, initial: null }),
       }),

--- a/code/helpers/enrichers/check.mjs
+++ b/code/helpers/enrichers/check.mjs
@@ -221,10 +221,12 @@ function adjustConfig(config) {
 
 const filterAbilityKey = key => {
   key = key.toLowerCase().trim();
-  if (key in ryuutama.config.abilityScores) return key;
+  if (Object.values(ryuutama.CONST.ABILITIES).includes(key)) return key;
 
   // Shorthand ability.
-  const [k] = Object.entries(ryuutama.config.abilityScores)
-    .find(([a, b]) => b.abbreviation.toLowerCase() === key) ?? [];
-  if (k) return k;
+  const k = Object.values(ryuutama.CONST.ABILITIES).find(key => {
+    const abbr = ryuutama.config.abilityScores[key].abbreviation.toLowerCase();
+    return abbr === key;
+  });
+  return k;
 };

--- a/lang/en.json
+++ b/lang/en.json
@@ -132,8 +132,7 @@
         },
         "baseDefensePoints": "Base Defense Points",
         "capacity": "Capacity",
-        "conditionHigh": "Bonus: {ability}",
-        "conditionHighTooltip": "Tip-Top Shape",
+        "conditionHigh": "Tip-Top Shape: {ability}",
         "conditionLow": "Out of Shape",
         "damageReductionMagical": "Magical: {value}",
         "damageReductionPhysical": "Physical: {value}",
@@ -147,6 +146,7 @@
         "incantationSpells": "Incantations",
         "initiative": "Initiative: {value}",
         "level": "Level {level}",
+        "rollCondition": "Roll Condition Check",
         "seasonAffinity": "Affinity",
         "shieldDodge": "Shield Dodge Value: {value}"
       },

--- a/main.mjs
+++ b/main.mjs
@@ -1,6 +1,7 @@
 import * as applications from "./code/applications/_module.mjs";
 import * as canvas from "./code/canvas/_module.mjs";
 import * as config from "./code/config.mjs";
+import * as constants from "./code/constants.mjs";
 import * as data from "./code/data/_module.mjs";
 import * as dice from "./code/dice/_module.mjs";
 import * as documents from "./code/documents/_module.mjs";
@@ -18,6 +19,7 @@ globalThis.ryuutama = {
   documents,
   helpers,
   utils,
+  CONST: constants,
   id: "ryuutama",
 };
 

--- a/templates/sheets/actors/traveler/effects.hbs
+++ b/templates/sheets/actors/traveler/effects.hbs
@@ -2,7 +2,7 @@
   <div class="contents">
     {{!-- CONDITION --}}
     <section class="condition banner-label">
-      <button class="value square" type="button" data-action="{{ifThen disabled 'rollCheck' 'configure'}}" data-config="condition" data-check="condition" {{disabled (not isInteractive)}}>
+      <button class="value square" type="button" data-action="{{ifThen disabled 'rollCheck' 'configure'}}" data-config="condition" data-check="condition" {{disabled (not isInteractive)}} {{#if disabled}} data-tooltip="RYUUTAMA.ACTOR.TRAVELER.rollCondition" {{/if}}>
         {{#if disabled}}
         <ryuutama-icon src="systems/ryuutama/assets/official/icons/check/condition.svg" inert></ryuutama-icon>
         <i class="hover fa-solid fa-dice-d10" inert></i>
@@ -10,10 +10,10 @@
         <i class="fa-solid fa-cog" inert></i>
         {{/if}}
       </button>
-      <span class="label">
+      <span class="label" {{#if condition.tooltip}} data-tooltip-text="{{condition.tooltip}}" {{/if}}>
         <span class="numeric-display">{{document.system.condition.value}}</span>
-        {{#if condition.active}}
-        <ryuutama-icon src="{{condition.abilityIcon}}" {{#if condition.high}} data-tooltip="RYUUTAMA.ACTOR.TRAVELER.conditionHighTooltip" {{/if}}></ryuutama-icon>
+        {{#if condition.high}}
+        <ryuutama-icon src="{{condition.abilityIcon}}"></ryuutama-icon>
         {{/if}}
       </span>
     </section>


### PR DESCRIPTION
Sets up the `CONST` module with an `ABILITIES` enum, which is enumerated over everywhere instead of `config.abilityScores`.