### PR TITLE
Add configuration dialog to `PartyData#placeMembers`

### DIFF
--- a/code/applications/apps/_module.mjs
+++ b/code/applications/apps/_module.mjs
@@ -4,6 +4,7 @@ export { default as AttackConfig } from "./attack-config.mjs";
 export { default as CheckConfigurationDialog } from "./check-configuration-dialog.mjs";
 export { default as ConditionConfig } from "./condition-config.mjs";
 export { default as DefenseConfig } from "./defense-config.mjs";
+export { default as PlaceMembersDialog } from "./place-members-dialog.mjs";
 export { default as ResourceConfig } from "./resource-config.mjs";
 export { default as RollRequestor } from "./roll-requestor.mjs";
 export { default as SourceConfig } from "./source-config.mjs";

--- a/code/applications/apps/advancement-dialog.mjs
+++ b/code/applications/apps/advancement-dialog.mjs
@@ -119,7 +119,7 @@ export default class AdvancementDialog extends HandlebarsApplicationMixin(Applic
     switch (partId) {
       case "footer":
         context.buttons = [{
-          label: "Confirm", icon: "fa-solid fa-check", type: "submit", disabled: !this.chain.isConfigured,
+          label: "COMMON.Confirm", icon: "fa-solid fa-check", type: "submit", disabled: !this.chain.isConfigured,
         }];
         break;
       case "advancements":

--- a/code/applications/apps/check-configuration-dialog.mjs
+++ b/code/applications/apps/check-configuration-dialog.mjs
@@ -143,7 +143,7 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
     const [abi1, abi2] = this.#configurations.rollConfig.abilities ?? [];
     context.abilities = { abi1, abi2 };
 
-    context.buttons = [{ label: "Confirm", type: "submit", icon: "fa-solid fa-check" }];
+    context.buttons = [{ label: "COMMON.Confirm", type: "submit", icon: "fa-solid fa-check" }];
     context.roll = this.actor.system._constructCheckRoll(
       this.#configurations.rollConfig,
       this.#configurations.dialogConfig,

--- a/code/applications/apps/place-members-dialog.mjs
+++ b/code/applications/apps/place-members-dialog.mjs
@@ -1,0 +1,160 @@
+/**
+ * @import RyuutamaActor from "../../documents/actor.mjs";
+ * @import { ApplicationConfiguration } from "@client/applications/_types.mjs";
+ */
+
+const { HandlebarsApplicationMixin, Application } = foundry.applications.api;
+
+/**
+ * @extends Application
+ * @mixes HandlebarsApplicationMixin
+ */
+export default class PlaceMembersDialog extends HandlebarsApplicationMixin(Application) {
+  /**
+   * Factory method for asynchronous behavior.
+   * @param {ApplicationConfiguration & { configuration?: object, document: RyuutamaActor }} options
+   * @returns {Promise<object>}   A promise that resolves once the dialog has been closed.
+   */
+  static async create(options) {
+    const { promise, resolve } = Promise.withResolvers();
+    const application = new this(options);
+    application.addEventListener("close", () => resolve(application.config), { once: true });
+    application.render({ force: true });
+    return promise;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    document: null,
+    tag: "form",
+    position: {
+      width: 420,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+    },
+    form: {
+      handler: PlaceMembersDialog.#onSubmit,
+      closeOnSubmit: false,
+      submitOnChange: true,
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    form: {
+      template: "systems/ryuutama/templates/apps/place-members-dialog/form.hbs",
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @param {ApplicationConfiguration & { configuration?: object, document: RyuutamaActor }} options
+   */
+  constructor({ configuration = {}, ...options }) {
+    if (!(options.document instanceof foundry.documents.Actor) || (options.document.type !== "party")) {
+      throw new Error("PlaceMembersDialog must be constructed with a Party actor.");
+    }
+    super(options);
+    this.#configuration = configuration;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The value to be returned by the form when submitted.
+   * @type {boolean}
+   */
+  #config = false;
+  get config() {
+    return this.#config;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The mutatable configuration.
+   * @type {object}
+   */
+  #configuration;
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get title() {
+    return _loc("RYUUTAMA.ACTOR.PARTY.PLACE_MEMBERS.title", { name: this.document.name });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The party actor placing members.
+   * @type {RyuutamaActor}
+   */
+  get document() {
+    return this.options.document;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The party actor placing members.
+   * @type {RyuutamaActor}
+   */
+  get party() {
+    return this.document;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.combat = game.combat;
+    context.rootId = `${this.party.uuid.replaceAll(".", "-")}-${this.id}`;
+    context.buttons = [{ label: "COMMON.Confirm", type: "submit", icon: "fa-solid fa-check" }];
+    context.inputs = (field, params) => foundry.applications.fields[field](params.hash).outerHTML;
+    context.configuration = this.#configuration;
+    context.memberOptions = this.party.system.members.map(m => ({ value: m.actor.id, label: m.actor.name }));
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle changes to inputs.
+   * @this PlaceMembersDialog
+   * @param {SubmitEvent} event
+   * @param {HTMLFormElement} form
+   * @param {FormDataExtended} formData
+   */
+  static #onChangeInputs(event, form, formData) {
+    foundry.utils.mergeObject(this.#configuration, formData.object);
+    this.render();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle final form submission.
+   * @this PlaceMembersDialog
+   * @param {SubmitEvent} event
+   * @param {HTMLFormElement} form
+   * @param {FormDataExtended} formData
+   */
+  static #onSubmit(event, form, formData) {
+    if (!event.submitter) PlaceMembersDialog.#onChangeInputs.call(this, event, form, formData);
+    else {
+      this.#config = true;
+      this.close();
+    }
+  }
+}

--- a/code/applications/sheets/actors/party.mjs
+++ b/code/applications/sheets/actors/party.mjs
@@ -234,10 +234,8 @@ export default class RyuutamaPartySheet extends RyuutamaBaseActorSheet {
    * @param {HTMLElement} target    The capturing html element that defined the [data-action].
    */
   static async #placeMembers(event, target) {
-    const isMaximized = this.rendered && !this.minimized;
-    if (isMaximized) await this.minimize();
-    await this.document.system.placeMembers();
-    if (isMaximized) this.maximize();
+    const configure = !event.shiftKey;
+    this.document.system.placeMembers({ configure });
   }
 
   /* -------------------------------------------------- */

--- a/code/data/actor/party.mjs
+++ b/code/data/actor/party.mjs
@@ -114,13 +114,44 @@ export default class PartyData extends foundry.abstract.TypeDataModel {
 
   /**
    * Place down the members of this party.
+   * @param {object} [options]
+   * @param {boolean} [options.configure=true]      Display a configuration dialog?
    * @returns {Promise<RyuutamaTokenDocument[]>}    A promise that resolves to the created tokens.
    */
-  async placeMembers() {
-    const promises = this.members.map(m => m.actor.getTokenDocument());
-    const tokens = await Promise.all(promises);
+  async placeMembers({ configure = true, ...configuration } = {}) {
+    const sheet = this.parent.sheet;
+
+    configuration = foundry.utils.mergeObject({
+      createCombatants: !!game.combat,
+      members: this.members.filter(m => !m.actor.getActiveTokens().length).map(m => m.actor.id),
+    }, configuration);
+
+    if (configure) {
+      const configured = await ryuutama.applications.apps.PlaceMembersDialog.create({
+        configuration, document: this.parent,
+      });
+      if (!configured) return null;
+    }
+
+    if (!configuration.members.length) return [];
+
+    const isMaximized = sheet.rendered && !sheet.minimized;
+    if (isMaximized) await sheet.minimize();
+
+    const promises = configuration.members.map(
+      id => this.members.get(id).actor.getTokenDocument({}, { parent: canvas.scene }),
+    );
+    let tokens = await Promise.all(promises);
     const data = tokens.map(token => token.toObject());
-    return canvas.tokens.placeTokens(data, { create: true });
+    tokens = await canvas.tokens.placeTokens(data, { create: true });
+
+    if (tokens.length && configuration.createCombatants) {
+      await getDocumentClass("Token").createCombatants(tokens, { combat: game.combat });
+    }
+
+    if (isMaximized) await sheet.maximize();
+
+    return tokens;
   }
 
   /* -------------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,12 @@
       },
       "PARTY": {
         "FIELDS": {},
+        "PLACE_MEMBERS": {
+          "createCombatants": "Create Combatants",
+          "createCombatantsHint": "Once placed, create combatants for the tokens in the currently active encounter. An encounter will be created if none is active.",
+          "members": "Members",
+          "title": "Place Members: {name}"
+        },
         "actorOwner": "Owner",
         "placeMembers": "Place Members",
         "removeRation": "Remove Ration"

--- a/templates/apps/place-members-dialog/form.hbs
+++ b/templates/apps/place-members-dialog/form.hbs
@@ -1,0 +1,15 @@
+<section>
+  <div class="form-group stacked">
+    <label>{{localize "RYUUTAMA.ACTOR.PARTY.PLACE_MEMBERS.members"}}</label>
+    <div class="form-fields">
+      {{{inputs "createMultiSelectInput" name="members" value=configuration.members type="checkboxes" options=memberOptions}}}
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="{{rootId}}-createCombatants">{{localize "RYUUTAMA.ACTOR.PARTY.PLACE_MEMBERS.createCombatants"}}</label>
+    <div class="form-fields">
+      {{{inputs "createCheckboxInput" name="createCombatants" value=configuration.createCombatants id=(concat rootId "-createCombatants")}}}
+    </div>
+    <p class="hint">{{localize "RYUUTAMA.ACTOR.PARTY.PLACE_MEMBERS.createCombatantsHint"}}</p>
+  </div>
+</section>

--- a/templates/chat/header.hbs
+++ b/templates/chat/header.hbs
@@ -3,7 +3,7 @@
   <span class="message-metadata">
     <time class="message-timestamp">{{timeSince document.timestamp}}</time>
     {{#if canDelete}}
-    <a aria-label="{{localize 'Delete'}}" class="message-delete" data-action="deleteMessage">
+    <a aria-label="{{localize 'COMMON.Delete'}}" class="message-delete" data-action="deleteMessage">
       <i class="fa-solid fa-trash" inert></i>
     </a>
     {{/if}}


### PR DESCRIPTION
- Allows configuring which members to place. Defaults to all except those with active tokens.
- Allows configuring whether to create combatants. Defaults to true if there is a current combat.
- Fixes a few i18n issues.
- Moves the sheet minimizing/maximizing logic out of the sheet and into the `PartyData#placeMembers` method.