### PR TITLE
[#297] Implement `CheckDie` die class for check rolls

### DIFF
--- a/code/applications/apps/attack-config.mjs
+++ b/code/applications/apps/attack-config.mjs
@@ -13,7 +13,7 @@ export default class AttackConfig extends DocumentConfig {
 
   /** @inheritdoc */
   get title() {
-    return _loc("RYUUTAMA.ATTACK.title", { name: this.document.name });
+    return _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.title", { name: this.document.name });
   }
 
   /* -------------------------------------------------- */
@@ -22,18 +22,43 @@ export default class AttackConfig extends DocumentConfig {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
 
-    const isPhysical = this.document.system._defaultAttackType === "physical";
-    context.accuracyPlaceholder = isPhysical
-      ? "@stats.strength + @stats.dexterity"
-      : "@stats.intelligence + @stats.spirit";
-    context.accuracyValue = context.disabled
-      ? this.document.system.attack.accuracy
-      : this.document.system._source.attack.accuracy;
+    const isPhysical = this.document.system.attack._defaultAttackType === "physical";
+    context.accuracyPlaceholder1 = _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.defaultAbility", {
+      ability: isPhysical
+        ? ryuutama.config.abilityScores.strength.abbreviation
+        : ryuutama.config.abilityScores.intelligence.abbreviation,
+    });
+    context.accuracyPlaceholder2 = _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.defaultAbility", {
+      ability: isPhysical
+        ? ryuutama.config.abilityScores.dexterity.abbreviation
+        : ryuutama.config.abilityScores.spirit.abbreviation,
+    });
 
-    context.damagePlaceholder = isPhysical ? "@stats.strength" : "@stats.spirit";
+    context.accuracyValue1 = context.disabled
+      ? this.document.system.attack.accuracy.die1
+      : this.document.system._source.attack.accuracy.die1;
+
+    context.accuracyValue2 = context.disabled
+      ? this.document.system.attack.accuracy.die2
+      : this.document.system._source.attack.accuracy.die2;
+
+    context.accuracyBonus = context.disabled
+      ? this.document.system.attack.accuracy.bonus
+      : this.document.system._source.attack.accuracy.bonus;
+
+    context.damagePlaceholder = _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.defaultAbility", {
+      ability: isPhysical
+        ? ryuutama.config.abilityScores.strength.abbreviation
+        : ryuutama.config.abilityScores.spirit.abbreviation,
+    });
+
     context.damageValue = context.disabled
-      ? this.document.system.attack.damage
-      : this.document.system._source.attack.damage;
+      ? this.document.system.attack.damage.die
+      : this.document.system._source.attack.damage.die;
+
+    context.damageBonus = context.disabled
+      ? this.document.system.attack.damage.bonus
+      : this.document.system._source.attack.damage.bonus;
 
     return context;
   }

--- a/code/applications/apps/check-configuration-dialog.mjs
+++ b/code/applications/apps/check-configuration-dialog.mjs
@@ -142,6 +142,7 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
     context.abilityOptions = ryuutama.CONST.ABILITIES._toConfig;
     const [abi1, abi2] = this.#configurations.rollConfig.abilities ?? [];
     context.abilities = { abi1, abi2 };
+    context.displayAbilities = [abi1, abi2].every(abi => Object.values(ryuutama.CONST.ABILITIES).includes(abi));
 
     context.buttons = [{ label: "COMMON.Confirm", type: "submit", icon: "fa-solid fa-check" }];
     context.roll = this.actor.system._constructCheckRoll(
@@ -165,7 +166,7 @@ export default class CheckConfigurationDialog extends HandlebarsApplicationMixin
 
     if (!context.showAccuracy) foundry.utils.setProperty(roll, "accuracy.consumeStamina", false);
     context.showCondition = roll.type === "condition";
-    context.showAbilities = !roll.formula;
+    context.showAbilities = !roll.formula && context.displayAbilities;
 
     const combatant = game.combat?.combatants.find(c => c.actor === this.actor);
 

--- a/code/data/_module.mjs
+++ b/code/data/_module.mjs
@@ -11,3 +11,4 @@ export * as fields from "./fields/_module.mjs";
 
 export { default as AbilityModel } from "./ability-model.mjs";
 export { default as ActionsModel } from "./actions-model.mjs";
+export { default as AttackModel } from "./attack-model.mjs";

--- a/code/data/actor/_types.mjs
+++ b/code/data/actor/_types.mjs
@@ -8,7 +8,8 @@
 
 /**
  * @typedef CheckRollConfig
- * @property {string[]} [abilities]
+ * @property {string[]} [abilities]                     Keys from `ryuutama.CONST.ABILITIES` or number-like strings
+ *                                                      representing die faces.
  * @property {string} [formula]                         An explicit formula can be provided, in which case
  *                                                      abilities are ignored for the formula creation. Modifiers
  *                                                      are still added on top.

--- a/code/data/actor/monster.mjs
+++ b/code/data/actor/monster.mjs
@@ -1,15 +1,12 @@
 import CreatureData from "./templates/creature.mjs";
 
-const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { EmbeddedDataField, HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 export default class MonsterData extends CreatureData {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      attack: new SchemaField({
-        accuracy: new ryuutama.data.fields.FormulaField(),
-        damage: new ryuutama.data.fields.FormulaField(),
-      }),
+      attack: new EmbeddedDataField(ryuutama.data.AttackModel),
       description: new SchemaField({
         value: new HTMLField(),
       }),
@@ -37,21 +34,6 @@ export default class MonsterData extends CreatureData {
     ...super.LOCALIZATION_PREFIXES,
     "RYUUTAMA.ACTOR.MONSTER",
   ];
-
-  /* -------------------------------------------------- */
-
-  /**
-   * What is the default attack type of this monster?
-   * The sum of its abilities determine whether it is best suited for using
-   * STR + DEX or INT + SPI.
-   * @type {"physical"|"mental"}
-   */
-  get _defaultAttackType() {
-    const { abilities } = this._source;
-    const phys = abilities.strength.value + abilities.dexterity.value;
-    const ment = abilities.intelligence.value + abilities.spirit.value;
-    return phys >= ment ? "physical" : "mental";
-  }
 
   /* -------------------------------------------------- */
 
@@ -92,23 +74,9 @@ export default class MonsterData extends CreatureData {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.#prepareAttack();
+    this.attack._prepareDefaults();
     this.#prepareDefense();
     this.#prepareResources();
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Prepare accuracy and damage.
-   */
-  #prepareAttack() {
-    const isPhysical = this._defaultAttackType === "physical";
-    const accuracy = isPhysical ? "@stats.strength + @stats.dexterity" : "@stats.intelligence + @stats.spirit";
-    const damage = isPhysical ? "@stats.strength" : "@stats.spirit";
-
-    if (!this.attack.accuracy) this.attack.accuracy = accuracy;
-    if (!this.attack.damage) this.attack.damage = damage;
   }
 
   /* -------------------------------------------------- */
@@ -155,10 +123,35 @@ export default class MonsterData extends CreatureData {
   _constructCheckConfigs(roll, dialog, message) {
     super._constructCheckConfigs(roll, dialog, message);
     switch (roll.type) {
-      case "accuracy": roll.formula = this.attack.accuracy; break;
-      case "condition": roll.condition.updateScore = false; break;
-      case "damage": roll.formula = this.attack.damage; break;
-      case "initiative": roll.formula = "@initiative.value"; dialog.configure ??= false; break;
+      case "accuracy":
+        roll.abilities = [this.attack.accuracy.die1, this.attack.accuracy.die2];
+        roll.modifier ??= 0;
+        roll.modifier += this.attack.accuracy.bonus;
+        break;
+      case "condition":
+        roll.condition.updateScore = false;
+        break;
+      case "damage":
+        roll.abilities = [this.attack.damage.die];
+        roll.modifier ??= 0;
+        roll.modifier += this.attack.damage.bonus;
+        break;
+      case "initiative":
+        roll.formula = "@initiative.value";
+        dialog.configure ??= false;
+        break;
     }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static migrateData(source, options, _state) {
+    if (typeof source.attack?.accuracy === "string") {
+      const { accuracy, damage } = source.attack;
+      const data = ryuutama.data.AttackModel._migrateFormulasToModelData(accuracy, damage);
+      source.attack = data;
+    }
+    return super.migrateData(source, options, _state);
   }
 }

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -512,18 +512,25 @@ export default class CreatureData extends BaseData {
   _constructCheckRoll(rollConfig = {}, dialogConfig = {}, messageConfig = {}) {
     let { parts, rollData } = this._prepareCheckModifiers(rollConfig, dialogConfig, messageConfig);
 
-    if (rollConfig.formula) {
-      parts.unshift(rollConfig.formula);
-    } else {
-      parts = [
-        `@stats.${rollConfig.abilities[0]}`,
-        (rollConfig.abilities.length > 1) ? `@stats.${rollConfig.abilities[1]}` : null,
-      ].concat(parts);
-    }
-
     const Cls = this.#determineRollClass(rollConfig, dialogConfig, messageConfig);
     const options = this.#constructRollOptions(rollConfig, dialogConfig, messageConfig);
-    const roll = new Cls(parts.filterJoin(" + "), rollData, options);
+
+    let roll;
+    if (rollConfig.formula) {
+      parts.unshift(rollConfig.formula);
+      roll = new Cls(parts.filterJoin(" + "), rollData, options);
+    } else {
+      const terms = Cls.fromAbilities(this.parent, rollConfig.abilities).terms;
+      const additionalTerms = new Cls(parts.filterJoin(" + "), rollData).terms;
+      if (additionalTerms.length) {
+        terms.push(
+          new foundry.dice.terms.OperatorTerm({ operator: "+" }),
+          ...additionalTerms,
+        );
+      }
+      roll = Cls.fromTerms(terms, options);
+    }
+
     if (rollConfig.critical?.allowed && rollConfig.critical.isCritical) roll.alter(2, 0);
     return roll;
   }

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -281,9 +281,12 @@ export default class CreatureData extends BaseData {
     const type = _loc(`RYUUTAMA.ROLL.TYPES.${rollConfig.type}`);
     const abilities = game.i18n
       .getListFormatter()
-      .format(rollConfig.abilities?.map(abi => ryuutama.config.abilityScores[abi].label) ?? []);
+      .format(
+        (rollConfig.abilities?.map(abi => ryuutama.config.abilityScores[abi]?.label) ?? [])
+          .filter(_ => _),
+      );
     const flavor = _loc(
-      `RYUUTAMA.ROLL.messageFlavor${rollConfig.abilities?.length ? "Abilities" : ""}`,
+      `RYUUTAMA.ROLL.messageFlavor${abilities.length ? "Abilities" : ""}`,
       { type, abilities },
     );
 

--- a/code/data/attack-model.mjs
+++ b/code/data/attack-model.mjs
@@ -17,37 +17,19 @@ export default class AttackModel extends foundry.abstract.DataModel {
         };
       });
       [2, 4, 6, 8, 10, 12, 20].forEach(faces => {
-        options[faces] = {
-          label: `d${faces}`,
-          group: groupF,
-        };
+        options[faces] = { label: `d${faces}`, group: groupF };
       });
       return options;
     };
 
     return {
       accuracy: new SchemaField({
-        die1: new StringField({
-          choices,
-          required: true,
-          initial: null,
-          nullable: true,
-        }),
-        die2: new StringField({
-          choices,
-          required: true,
-          initial: null,
-          nullable: true,
-        }),
+        die1: new StringField({ choices, required: true, initial: null, nullable: true }),
+        die2: new StringField({ choices, required: true, initial: null, nullable: true }),
         bonus: new NumberField({ nullable: true, initial: null }),
       }),
       damage: new SchemaField({
-        die: new StringField({
-          choices,
-          required: true,
-          initial: null,
-          nullable: true,
-        }),
+        die: new StringField({ choices, required: true, initial: null, nullable: true }),
         bonus: new NumberField({ nullable: true, initial: null }),
       }),
     };

--- a/code/data/attack-model.mjs
+++ b/code/data/attack-model.mjs
@@ -1,0 +1,142 @@
+const { NumberField, SchemaField, StringField } = foundry.data.fields;
+
+export default class AttackModel extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    const choices = () => {
+      const options = {};
+      const { groupA, groupF } = {
+        groupA: _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.groupAbility"),
+        groupF: _loc("RYUUTAMA.ACTOR.MONSTER.ATTACK.groupFaces"),
+      };
+
+      Object.values(ryuutama.CONST.ABILITIES).forEach(ability => {
+        options[ability] = {
+          label: ryuutama.config.abilityScores[ability].label,
+          group: groupA,
+        };
+      });
+      [2, 4, 6, 8, 10, 12, 20].forEach(faces => {
+        options[faces] = {
+          label: `d${faces}`,
+          group: groupF,
+        };
+      });
+      return options;
+    };
+
+    return {
+      accuracy: new SchemaField({
+        die1: new StringField({
+          choices,
+          required: true,
+          initial: null,
+          nullable: true,
+        }),
+        die2: new StringField({
+          choices,
+          required: true,
+          initial: null,
+          nullable: true,
+        }),
+        bonus: new NumberField({ nullable: true, initial: null }),
+      }),
+      damage: new SchemaField({
+        die: new StringField({
+          choices,
+          required: true,
+          initial: null,
+          nullable: true,
+        }),
+        bonus: new NumberField({ nullable: true, initial: null }),
+      }),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * What is the default attack type of this monster?
+   * The sum of its abilities determine whether it is best suited for using
+   * STR + DEX or INT + SPI.
+   * @type {"physical"|"mental"}
+   */
+  get _defaultAttackType() {
+    const { abilities } = this.parent._source;
+    const physical = abilities.strength.value + abilities.dexterity.value;
+    const mental = abilities.intelligence.value + abilities.spirit.value;
+    return physical >= mental ? "physical" : "mental";
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Set defaults for dice used unless overridden.
+   */
+  _prepareDefaults() {
+    const type = this._defaultAttackType;
+    this.accuracy.die1 ??= (type === "physical") ? "strength" : "intelligence";
+    this.accuracy.die2 ??= (type === "physical") ? "dexterity" : "spirit";
+    this.damage.die ??= (type === "physical") ? "strength" : "spirit";
+  }
+
+  /* -------------------------------------------------- */
+  /*   Deprecations & Migrations                        */
+  /* -------------------------------------------------- */
+
+  /**
+   * Migrate a accuracy and damage formulas to new model data.
+   * @param {string} [accuracy]
+   * @param {string} [damage]
+   * @returns {object}
+   */
+  static _migrateFormulasToModelData(accuracy, damage) {
+    const data = {
+      accuracy: {
+        die1: null,
+        die2: null,
+        bonus: null,
+      },
+      damage: {
+        die: null,
+        bonus: null,
+      },
+    };
+
+    if (accuracy) {
+      try {
+        const roll = new Roll(accuracy);
+        const abilities = [...accuracy.matchAll(/@stats\.(strength|dexterity|intelligence|spirit)/g) ?? []];
+
+        let d1;
+        let d2;
+
+        if (abilities[0]?.[1]) d1 = abilities[0][1];
+        if (abilities[1]?.[1]) d2 = abilities[1][1];
+        d1 ??= roll.dice[0]?.faces ?? null;
+        d2 ??= roll.dice[1]?.faces ?? null;
+
+        data.accuracy.die1 = d1;
+        data.accuracy.die2 = d2;
+        const bonus = roll.terms.find(term => (term instanceof foundry.dice.terms.NumericTerm) && term.number);
+        if (bonus) data.accuracy.bonus = bonus.number || null;
+      } catch (err) {
+        console.warn(`Failed to migrate monster 'Accuracy' data: ${accuracy}`);
+      }
+    }
+
+    if (damage) {
+      try {
+        const roll = new Roll(damage);
+        const ability = damage.match(/@stats\.(strength|dexterity|intelligence|spirit)/)?.[1];
+        data.damage.die = ability ? ability : roll.dice[0]?.faces ?? null;
+        const bonus = roll.terms.find(term => (term instanceof foundry.dice.terms.NumericTerm) && term.number);
+        if (bonus) data.damage.bonus = bonus.number || null;
+      } catch (err) {
+        console.warn(`Failed to migrate monster 'Damage' data: ${damage}`);
+      }
+    }
+
+    return data;
+  }
+}

--- a/code/data/attack-model.mjs
+++ b/code/data/attack-model.mjs
@@ -113,8 +113,10 @@ export default class AttackModel extends foundry.abstract.DataModel {
 
         if (abilities[0]?.[1]) d1 = abilities[0][1];
         if (abilities[1]?.[1]) d2 = abilities[1][1];
-        d1 ??= roll.dice[0]?.faces ?? null;
-        d2 ??= roll.dice[1]?.faces ?? null;
+
+        const dice = [...roll.dice];
+        d1 ??= dice.pop()?.faces ?? null;
+        d2 ??= dice.pop()?.faces ?? null;
 
         data.accuracy.die1 = d1;
         data.accuracy.die2 = d2;

--- a/code/dice/_module.mjs
+++ b/code/dice/_module.mjs
@@ -1,4 +1,5 @@
 export { default as BaseRoll } from "./base-roll.mjs";
+export { default as CheckDie } from "./check-die.mjs";
 export { default as CheckRoll } from "./check-roll.mjs";
 export { default as DamageRoll } from "./damage-roll.mjs";
 export { default as HealingRoll } from "./healing-roll.mjs";

--- a/code/dice/check-die.mjs
+++ b/code/dice/check-die.mjs
@@ -44,11 +44,11 @@ export default class CheckDie extends foundry.dice.terms.Die {
   /**
    * Construct a die using an actor's ability.
    * @param {RyuutamaActor} actor
-   * @param {string} ability
+   * @param {string} ability    A key in `ryuutama.CONST.ABILITIES` or a number-like string.
    * @returns {CheckDie}
    */
   static fromAbility(actor, ability) {
-    const faces = actor.system.abilities[ability].faces;
+    const faces = Number.isNumeric(ability) ? Number(ability) : actor.system.abilities[ability].faces;
     return new this({ faces, options: { ability } });
   }
 }

--- a/code/dice/check-die.mjs
+++ b/code/dice/check-die.mjs
@@ -1,0 +1,54 @@
+/**
+ * @import RyuutamaActor from "../documents/actor.mjs";
+ */
+
+export default class CheckDie extends foundry.dice.terms.Die {
+  /**
+   * Did the die roll its maximum value?
+   * @type {boolean}
+   */
+  get isMax() {
+    if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
+    const active = this.results.filter(result => result.active);
+    return (active.length > 0) && active.every(result => result.result === this.faces);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Did the die roll its minimum value?
+   * @type {boolean}
+   */
+  get isMin() {
+    if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
+    const active = this.results.filter(result => result.active);
+    return (active.length > 0) && active.every(result => result.result === 1);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Did the die roll a 6?
+   * @type {boolean}
+   */
+  get isSix() {
+    if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
+    const active = this.results.filter(result => result.active);
+    return (active.length > 0) && active.every(result => result.result === 6);
+  }
+
+  /* -------------------------------------------------- */
+  /*   Factory Methods                                  */
+  /* -------------------------------------------------- */
+
+  /**
+   * Construct a die using an actor's ability.
+   * @param {RyuutamaActor} actor
+   * @param {string} ability
+   * @returns {CheckDie}
+   */
+  static fromAbility(actor, ability) {
+    const faces = actor.system.abilities[ability].faces;
+    return new this({ faces, options: { ability } });
+  }
+}

--- a/code/dice/check-roll.mjs
+++ b/code/dice/check-roll.mjs
@@ -28,18 +28,8 @@ export default class CheckRoll extends BaseRoll {
    */
   get isCritical() {
     if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
-    if (!this.dice.length) return false;
     const checkDice = this.checkDice;
-    if (checkDice.length) {
-      return checkDice.every(die => die.isMax) || checkDice.every(die => die.isSix);
-    }
-
-    // For compatibility with monsters which do not currently always construct rolls with CheckDie.
-    return this.dice.every(die => {
-      return die.results.every(result => result.result === 6);
-    }) || this.dice.every(die => {
-      return die.results.every(result => result.result === die.faces);
-    });
+    return !!checkDice.length && (checkDice.every(die => die.isMax) || checkDice.every(die => die.isSix));
   }
 
   /* -------------------------------------------------- */
@@ -63,16 +53,8 @@ export default class CheckRoll extends BaseRoll {
    */
   get isFumble() {
     if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
-    if (!this.dice.length) return false;
     const checkDice = this.checkDice;
-    if (checkDice.length) {
-      return checkDice.every(die => die.isMin);
-    }
-
-    // For compatibility with monsters which do not currently always construct rolls with CheckDie.
-    return this.dice.every(die => {
-      return die.results.every(result => result.result === 1);
-    });
+    return !!checkDice.length && checkDice.every(die => die.isMin);
   }
 
   /* -------------------------------------------------- */

--- a/code/dice/check-roll.mjs
+++ b/code/dice/check-roll.mjs
@@ -1,8 +1,23 @@
 import BaseRoll from "./base-roll.mjs";
 
+/**
+ * @import CheckDie from "./check-die.mjs";
+ * @import RyuutamaActor from "../documents/actor.mjs";
+ */
+
 export default class CheckRoll extends BaseRoll {
   /** @inheritdoc */
   static PART_TYPE = "check";
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The check dice.
+   * @type {CheckDie[]}
+   */
+  get checkDice() {
+    return this.dice.filter(die => die instanceof ryuutama.dice.CheckDie);
+  }
 
   /* -------------------------------------------------- */
 
@@ -13,6 +28,13 @@ export default class CheckRoll extends BaseRoll {
    */
   get isCritical() {
     if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
+    if (!this.dice.length) return false;
+    const checkDice = this.checkDice;
+    if (checkDice.length) {
+      return checkDice.every(die => die.isMax) || checkDice.every(die => die.isSix);
+    }
+
+    // For compatibility with monsters which do not currently always construct rolls with CheckDie.
     return this.dice.every(die => {
       return die.results.every(result => result.result === 6);
     }) || this.dice.every(die => {
@@ -41,6 +63,13 @@ export default class CheckRoll extends BaseRoll {
    */
   get isFumble() {
     if (!this._evaluated) throw new Error("Cannot check for state of a Check prior to evaluation.");
+    if (!this.dice.length) return false;
+    const checkDice = this.checkDice;
+    if (checkDice.length) {
+      return checkDice.every(die => die.isMin);
+    }
+
+    // For compatibility with monsters which do not currently always construct rolls with CheckDie.
     return this.dice.every(die => {
       return die.results.every(result => result.result === 1);
     });
@@ -69,5 +98,25 @@ export default class CheckRoll extends BaseRoll {
     const tn = this.options.target;
     if (Number.isNumeric(tn)) return Number(tn);
     return null;
+  }
+
+  /* -------------------------------------------------- */
+  /*   Factory Methods                                  */
+  /* -------------------------------------------------- */
+
+  /**
+   * Construct a roll from an actor and selected abilities.
+   * @param {RyuutamaActor} actor   The actor whose abilities to use.
+   * @param {string[]} abilities    The abilities to use. This array may contain duplicates.
+   * @returns {CheckRoll}
+   */
+  static fromAbilities(actor, abilities) {
+    const dice = abilities.map(ability => ryuutama.dice.CheckDie.fromAbility(actor, ability));
+    const terms = dice.reduce((acc, die, index, set) => {
+      acc.push(die);
+      if (index !== set.length - 1) acc.push(new foundry.dice.terms.OperatorTerm({ operator: "+" }));
+      return acc;
+    }, []);
+    return CheckRoll.fromTerms(terms);
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -105,8 +105,9 @@
       },
       "MONSTER": {
         "FIELDS": {
-          "attack.accuracy.label": "Accuracy Formula",
-          "attack.damage.label": "Damage Formula",
+          "attack.accuracy.bonus.label": "Bonus",
+          "attack.damage.bonus.label": "Bonus",
+          "attack.damage.die.label": "Ability",
           "description.special.name.label": "Special Ability",
           "description.value.label": "Description",
           "details.category.label": "Monster Category",
@@ -114,6 +115,16 @@
           "details.level.label": "Level",
           "environment.season.label": "Season",
           "initiative.value.label": "Initiative"
+        },
+        "ATTACK": {
+          "abilities": "Abilities",
+          "ability": "Ability",
+          "accuracy": "Accuracy",
+          "damage": "Damage",
+          "defaultAbility": "Default ({ability})",
+          "groupAbility": "Ability",
+          "groupFaces": "Faces",
+          "title": "Configure Attack: {name}"
         },
         "CATEGORIES": {
           "demon": "Demon",
@@ -346,10 +357,6 @@
           "choice.chosen.hint": "Choose a weapon type to master. Making an attack with a weapon type that you have not mastered incurs a 1 HP penalty with each attack."
         }
       }
-    },
-
-    "ATTACK": {
-      "title": "Configure Attack: {name}"
     },
     "CONDITION": {
       "title": "Configure Condition: {name}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -118,7 +118,6 @@
         },
         "ATTACK": {
           "abilities": "Abilities",
-          "ability": "Ability",
           "accuracy": "Accuracy",
           "damage": "Damage",
           "defaultAbility": "Default ({ability})",

--- a/main.mjs
+++ b/main.mjs
@@ -136,6 +136,9 @@ Hooks.once("init", () => {
     DamageRoll: dice.DamageRoll,
     HealingRoll: dice.HealingRoll,
   });
+  Object.assign(CONFIG.Dice.termTypes, {
+    CheckDie: dice.CheckDie,
+  });
 
   // Register sheets.
   foundry.applications.apps.DocumentSheetConfig.registerSheet(

--- a/src/actors/animals-animals000000000/animal-ii-animalii00000000.json
+++ b/src/actors/animals-animals000000000/animal-ii-animalii00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>Mid-sized dog, young wolf, etc.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Animal II",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254593324,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471118,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/animals-animals000000000/animal-iii-animaliii0000000.json
+++ b/src/actors/animals-animals000000000/animal-iii-animaliii0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>Large dog, adult wolf, large hawk, etc.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Animal III",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254628880,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471120,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/animals-animals000000000/animal-iv-animaliv00000000.json
+++ b/src/actors/animals-animals000000000/animal-iv-animaliv00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 10,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>Alpha wolf, small bear, etc.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Animal IV",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254655274,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471120,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/animals-animals000000000/animal-v-animalv000000000.json
+++ b/src/actors/animals-animals000000000/animal-v-animalv000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 10,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>Lion, large bear, etc.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Animal V",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254681931,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471120,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/black-death-skull-blackdeathskull0.json
+++ b/src/actors/demons-demons0000000000/black-death-skull-blackdeathskull0.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 13,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>One of the strongest demons known to man. It looks like a giant black skull, and has the power to control rats that are infected with the plague, driving them to multiply and spread the disease until huge numbers of people are infected. Anyone infected with this plague is afflicted with boils and dies within a week. It is said that the only cure is to defeat this monster, though there may be a certain high level healer or magician who can cure it...</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Black Death Skull",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>As plague rats infest the battle area, everyone in battle with this monster suffers [Sick: 13].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252787459,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471133,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252787447,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471133,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/decayter-decayter00000000.json
+++ b/src/actors/demons-demons0000000000/decayter-decayter00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A low-level demon that looks like a ball of green hair about 20cm across. Its name means “One who causes decay,” and it is aptly named, for its very touch causes decay in living things. When possible, decayters seek to live in cities, or other places where they can cause a great deal of decay - a trait that causes them to be especially hated by restaurateurs. As a result, people will often band together during the summer months to hunt these demons.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Decayter",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Decayters are able to cause decay in any living thing that they touch. Any character hit by a Decayter's attack suffers [Injury: 6].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252504420,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471139,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252504413,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471138,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/dragon-madder-dragonmadder0000.json
+++ b/src/actors/demons-demons0000000000/dragon-madder-dragonmadder0000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 10,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A parasitic high-level demon that makes its home in a dragon's maw. They are usually about fifty centimeters tall and look like clowns with deeply unsettling leers. The dragon madder targets dragons that are weak or in pain, and slowly drives them insane with ever increasing agony until the dragon goes berserk. The only way to destroy these demons is to enter the dragon's mouth and attack it directly.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Dragon Madder",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can use all mid-level spells, including incantation spells and up to mid-level spells of any season of the GM's choice.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252626998,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471140,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252626992,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471140,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/evil-soul-evilsoul00000000.json
+++ b/src/actors/demons-demons0000000000/evil-soul-evilsoul00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>The weakest demon in the entire world. They look like tiny people with strings holding them up - so tiny, in fact, that they can be blown into cities by heavy winds. While they aren't very dangerous directly, the tricks they play can have a negative long-term effect on people.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Evil Soul",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Anyone that is hit by an Evil Soul's attack suffers [Exhaustion: 6].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252356710,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471141,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252356700,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471141,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/meta-gnoll-metagnoll0000000.json
+++ b/src/actors/demons-demons0000000000/meta-gnoll-metagnoll0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A demon that looks like a meter-tall hyena that somehow has the appearance of cloudy alcohol. It is said that this demon contaminates all alcohol that it touches, causing it to become unusually addictive. Even worse, anyone who drinks this tainted liquor will go wild and destroy things. Meta Gnolls prefer to lurk in taverns, in order to turn the entire town into mean alcoholics.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Meta Gnoll",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Anyone that drinks alcohol tainted by a Meta Gnoll suffers [Muddled: 10]. Also, the Meta Gnoll gives off an intoxicating aura, causing 1 MP damage to all areas every round.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252548828,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471154,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252548822,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471153,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/poison-toad-poisontoad000000.json
+++ b/src/actors/demons-demons0000000000/poison-toad-poisontoad000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A demon in the shape of a small black frog. They are usually about 20cm long, but they can double in size during the summer. Though they don't have much in the way of attack power, they can turn things - such as food - into poison. Anyone that eats food tainted by the Poison Toad gets food poisoning. It is said that these demons are spawned from a giant toad called the King Poison Toad.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Poison Toad",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>If a character eats or holds something poisoned by the Poison Toad, they suffer [Poison: 6]. This also occurs if a character is hit by a Poison Toad.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252444625,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471160,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252444613,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471160,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demons-demons0000000000/red-demon-reddemon00000000.json
+++ b/src/actors/demons-demons0000000000/red-demon-reddemon00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 16,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A high-level demon with blood-red skin. It looks like a four-meter tall humanoid with large red wings and huge claws. It hates all life, and has the power to infect others with its emotion, inciting hatred and negative feelings in its vicinity. The area in which a Red Demon appears often erupts in war and violence; its goal is to set the entire world alight with war.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Red Demon",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When characters encounter a Red Demon, they suffer [Shock: 10].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761252988444,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471162,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761252988427,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471162,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/frozen-statue-frozenstatue0000.json
+++ b/src/actors/demonstones-demonstones00000/frozen-statue-frozenstatue0000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + 1d8",
-      "damage": ""
+      "accuracy": {
+        "die1": "strength",
+        "die2": "8",
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Sometimes a living being may be frozen to death by a magical frost, creating a Frozen Statue, which looks like a sleeping creature encased in ice. Although they retain the intelligence and abilities of the original being, they are incapable of reason, making them incredibly dangerous.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Frozen Statue",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Any characters killed by this attack are encased in ice. This attack targets all areas with Accuracy [[/check accuracy formula=\"d8 + d8\"]] damage [[/check damage d8]].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081648,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471144,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291471849,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471143,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/leemee-alone-leemeealone00000.json
+++ b/src/actors/demonstones-demonstones00000/leemee-alone-leemeealone00000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A giant made completely of gold. The giant is said to be warm-hearted and willing to help troubled travelers in need, but over the years treasure-hungry adventurers have hunted it down for its gold. The giant now yearns for a solitary life.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Leemee Alone",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291624645,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471124,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/meteoric-iron-meteoriciron0000.json
+++ b/src/actors/demonstones-demonstones00000/meteoric-iron-meteoriciron0000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A sliver of rock that fell from a place beyond the moon and stars. At first it looks just like a normal hunk of iron, but actually it has a powerful intellect and can communicate with humans via telepathy. Used to make incredible weapons and armor, the weapons used by famous heroes are invariably made of meteoric iron.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Meteoric Iron",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Meteoric Iron always receives a +1 bonus to both Initiative and Condition (included in its stats); any item made of this iron receives the same. Any armor made from this becomes a “plus 1” armor.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081679,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471154,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291211557,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471154,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/moai-moai000000000000.json
+++ b/src/actors/demonstones-demonstones00000/moai-moai000000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": "@stats.intelligence"
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": "intelligence",
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A human face that seems to appear out of sand or rock. Due to their cowardice, they almost never show themselves before humans, but they are known to help travelers in need by moving rocks or sand. They are also known to fight people that destroy rocks. Some towns with many stone buildings revere them as guardian gods.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Moai",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>With their ability to control stones in its vicinity, Moai can make 3 new objects, but they must be made of sand or stone.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081683,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471157,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291384851,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471156,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/petrified-fossil-petrifiedfossil0.json
+++ b/src/actors/demonstones-demonstones00000/petrified-fossil-petrifiedfossil0.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>An ancient being that was magically petrified rather than fossilized, preserving their form as if they were still alive. Though their appearance hasn't changed since their “death,” there may be some Petrified Fossils that represent beings that no longer exist. These creatures are tougher than they seem.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Petrified Fossil",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster may attack two times per turn.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081693,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471159,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291522145,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471159,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/rock-eater-rockeater0000000.json
+++ b/src/actors/demonstones-demonstones00000/rock-eater-rockeater0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large, rock-eating giant. Because it does not eat flesh, it poses no direct threat to humans, but travelers may be put at risk by the violence of their movements while feeding.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Rock Eater",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291322364,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471129,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/demonstones-demonstones00000/symphonic-crystal-symphoniccrystal.json
+++ b/src/actors/demonstones-demonstones00000/symphonic-crystal-symphoniccrystal.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.intelligence + @stats.spirit",
-      "damage": "@stats.spirit"
+      "accuracy": {
+        "die1": "intelligence",
+        "die2": "spirit",
+        "bonus": null
+      },
+      "damage": {
+        "die": "spirit",
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A crystal found deep in the back of caves that can be tens of meters high. Once every number of years, the entire crystal vibrates, producing an incredibly beautiful melody. It is said that this sound is the accumulation of all the sounds from things above ground over a long period of time. Those that hear the sound feel it resonate within, and swear that they themselves are becoming one with the world.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Symphonic Crystal",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>All that hear the melody created by the Symphonic Crystal gain a permanent +1 to Condition.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081707,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471165,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291278794,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471165,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/eggs-eggs000000000000/riding-egg-ridingegg0000000.json
+++ b/src/actors/eggs-eggs000000000000/riding-egg-ridingegg0000000.json
@@ -10,9 +10,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "initiative": {
       "value": 12
@@ -55,8 +53,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.dexterity + @stats.dexterity",
-      "damage": "1d6"
+      "accuracy": {
+        "die1": "dexterity",
+        "die2": "dexterity",
+        "bonus": null
+      },
+      "damage": {
+        "die": "6",
+        "bonus": null
+      }
     },
     "environment": {
       "season": "autumn"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -174,6 +178,11 @@
       "system": {
         "description": {
           "value": "<p>It is said that if a Riding Egg is defeated by reducing its HP to exactly 0, a blessing occurs. All members of a party so blessed will receive 300 XP.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -188,10 +197,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081699,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471162,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759792062905,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471162,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/eggs-eggs000000000000/running-egg-runningegg000000.json
+++ b/src/actors/eggs-eggs000000000000/running-egg-runningegg000000.json
@@ -10,9 +10,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "initiative": {
       "value": 10
@@ -55,8 +53,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.dexterity + @stats.dexterity",
-      "damage": "1d6"
+      "accuracy": {
+        "die1": "dexterity",
+        "die2": "dexterity",
+        "bonus": null
+      },
+      "damage": {
+        "die": "6",
+        "bonus": null
+      }
     },
     "environment": {
       "season": "winter"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -174,6 +178,11 @@
       "system": {
         "description": {
           "value": "<p>It is said that if a Running Egg is defeated by reducing its HP to exactly 0, a blessing occurs. All members of a party so blessed will receive 200 XP.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -188,10 +197,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081701,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471163,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759791937802,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471163,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/eggs-eggs000000000000/walking-egg-walkingegg000000.json
+++ b/src/actors/eggs-eggs000000000000/walking-egg-walkingegg000000.json
@@ -10,9 +10,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "initiative": {
       "value": 9
@@ -55,8 +53,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.dexterity + @stats.dexterity",
-      "damage": "1d6"
+      "accuracy": {
+        "die1": "dexterity",
+        "die2": "dexterity",
+        "bonus": null
+      },
+      "damage": {
+        "die": "6",
+        "bonus": null
+      }
     },
     "environment": {
       "season": "spring"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -174,6 +178,11 @@
       "system": {
         "description": {
           "value": "<p>It is said that if a Walking Egg is defeated by reducing its HP to exactly 0, a blessing occurs. All members of a party so blessed will receive 100 XP.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -188,10 +197,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081719,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471169,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759790688989,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471169,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/gobroach-gobroach00000000.json
+++ b/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/gobroach-gobroach00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 1",
-      "damage": "@stats.strength + 1"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 1
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 1
+      }
     },
     "description": {
       "value": "<p>The only thing that gobroaches enjoy is filth, so they are consumed with corrupting the world. They usually live underground but may venture above ground to attack a human settlement, in order to dirty it up. Though they look like disgusting black-carapaced insects, powerful gobroaches are said to have the power to change into human form, so that they can enter and pollute human cities.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Gobroach",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack two times in 1 round.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081653,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471145,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760293061341,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471145,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/radioactive-gobroach-radioactivegobro.json
+++ b/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/radioactive-gobroach-radioactivegobro.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 2",
-      "damage": "@stats.strength + 2"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 2
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 2
+      }
     },
     "description": {
       "value": "<p>The most powerful of all gobroaches. These gobroaches love filth so much that they exposed themselves to contaminated materials, causing a sudden change in their bodies and granting them immense power. These radioactive gobroaches have concealed the source of their contaminated power, allowing them to rule over all of gobroach kind.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Radioactive Gobroach",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Radioactive Gobroaches are able magicians and have access to all Summer magic.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081697,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471161,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760293289277,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471161,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/sky-gobroach-skygobroach00000.json
+++ b/src/actors/intelligent-races-intelligentraces/gobroaches-gobroaches000000/sky-gobroach-skygobroach00000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 1",
-      "damage": "@stats.strength + 1"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 1
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 1
+      }
     },
     "description": {
       "value": "<p>A certain percentage of gobroaches grow large enough to grow wings that sprout from their carapace. The filth that spreads when they flap their wings gets into the eyes of those around them, forcing their opponents to freeze in their tracks. Like normal gobroaches, they are determined to make the world a dirty place, but they are more willing to use underhanded techniques.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Sky Gobroach",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>During battle, if a Sky Gobroach flaps his wings, any character that doesn't have eye protection must make a [SPI+SPI] check at difficulty 8. Those that fail may only Defend on their next action.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081703,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471164,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760293207261,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471163,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/hobneko-goblin-hobnekogoblin000.json
+++ b/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/hobneko-goblin-hobnekogoblin000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 1",
-      "damage": "@stats.strength + 1"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 1
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 1
+      }
     },
     "description": {
       "value": "<p>Hobneko-goblins are said to be a close cousin to the Neko-goblins. Though they are generally larger than Neko Goblins, they share the same easy-going attitude. However, they are said surpass humans at hunting and so are often used by warring nations as mercenaries. Their top-pots are larger than their smaller cousins and are often filled with weapons. They are often heard crying, “Hobunya!”</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Hobneko-Goblin",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>They are born hunters, with eyes that can see at night and noses that never forget a scent. They can use and equip items, too.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081662,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471149,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291134981,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471149,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/koneko-goblin-konekogoblin0000.json
+++ b/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/koneko-goblin-konekogoblin0000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Koneko-goblins are used as underlings by Neko-goblins. They look much the same as Neko-goblins, but are smaller and weaker, and are thus often bullied by the larger species. They usually grow to a height of about one meter. They are often much more docile then their larger cousins and sometimes live in and around human settlements. They always keep a small pot on their heads to carry items, called a top-pot. They have an annoying habit of ending their sentences with “Gobunya~!”</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Koneko-Goblin",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>They are born hunters, with eyes that can see at night and noses that never forget a scent. They can use and equip items, too.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081668,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471150,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290916514,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471150,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/neko-goblin-nekogoblin000000.json
+++ b/src/actors/intelligent-races-intelligentraces/nekogoblins-nekogoblins00000/neko-goblin-nekogoblin000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Though Neko-goblins (or Nekogoblins) have the word goblin in their name, they have nothing to do with the goblins of other universes. They resemble upright-walking cats, and have personalities to match. They grow to a height of one-hundred thirty centimeters. They keep a top-pot on their head at all times and fill it with important items as they travel the world. They sometimes meddle with and/or trade with humans. Depending on the region, they may wear things on their heads other than pots. They often cry “Gobunya!”</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Neko-Goblin",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>They are born hunters, with eyes that can see at night and noses that never forget a scent. They can use and equip items, too.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081689,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471158,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291051810,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471158,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/coppelia-coppelia00000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/coppelia-coppelia00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>These are created with a fusion of magic and technical skill, producing a magical creature that looks almost human. Indeed, it is said that some Coppelia are indistinguishable from humans, from their breathing down to their body heat. While they usually follow the commands of their creators, it is also said that some Coppelia have minds of their own.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Coppelia",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When meeting a Coppelia, a character must pass a [INT+SPI] check (difficulty 13) or believe that it is actually human.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761253529988,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471137,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253529979,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471137,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/factory-factory000000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/factory-factory000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 14,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 2,
@@ -65,7 +70,8 @@
       "value": "<p>These are magical constructs in the shape of small castles. They are said to have been made by the most powerful sorcerers, long ago, since today's magic lacks the power to create them. They don't have very powerful fighting skills, but they have the ability to consume weapons and spit out the magical animals that it produces within itself. Sometimes they make deals with towns in need of protection.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Factory",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>On its turn, this factory may spend 5 HP to create any magical animal in addition to its action. It may use this ability 3 times in one day.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761253662103,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471142,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253662085,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471142,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/haniwa-golem-haniwagolem00000.json
+++ b/src/actors/magical-creatures-magicalcreatures/haniwa-golem-haniwagolem00000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>These magical beings are created from kiln-fired clay in various humanoid shapes. Though they are not very durable and will often fall apart when struck with weapons, they are very easy to repair. They are not really made for combat; their main use is everyday chores though in some regions they are used as decor.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Haniwa Golem",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack two times in 1 round.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761253572744,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471147,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253572738,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471147,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/magic-hand-magichand0000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/magic-hand-magichand0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": null,
@@ -65,7 +70,8 @@
       "value": "<p>A magical hand made by some mad magician. It appears as a large hand wearing a white glove. They seem to display the same intelligence as a human and can communicate through sign language. Records exist of other giant body parts, such as magic eyes and feet, so it is thought that magic hands are a part of some ancient giant. It is thought that if someone were to gather up the parts of this giant, it would be resurrected, but so far nobody has attempted this.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Magic Hand",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253480492,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471125,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/mimic-hut-mimichut00000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/mimic-hut-mimichut00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 2,
@@ -65,7 +70,8 @@
       "value": "<p>These huts are said to be made by the cruelest of magicians. A mimic hut appears to be nothing more than a small hut with a single door, waiting on the side of the road, but is actually a large and fierce magical creature. The instant anyone so much as sets foot inside the hut, a sticky fluid entraps them, keeping them in place to be devoured. Only death awaits those unfortunate enough to be caught by the mimic hut. Though normally subtle, if it senses prey lingering in the area without going inside, it may resort to direct attacks.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Mimic Hut",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>If a character enters a Mimic Hut without realizing, or is hit by its attack, they must pass a [INT+INT] check (difficulty 10) or lose their next action.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761253620216,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471156,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253620210,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471156,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/slime-slime00000000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/slime-slime00000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": null,
@@ -65,7 +70,8 @@
       "value": "<p>Slimes are magical creatures that resemble slime molds. Though most have oozing, jelly-like bodies, there are some with a cuter, rounded shape. Most slimes are blue or green and live in the shade, beneath rocks or otherwise out of direct sunlight. The largest slime on record was larger than 10 meters in size. Care must be taken when fighting slimes, as any slime that remains after the battle will eventually grow back into a full slime.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Slime",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>If a character is hit by a slime's attack, their armor's durability is lowered by 1.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761253413514,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471164,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253413507,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471164,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/magical-creatures-magicalcreatures/toy-soldier-toysoldier000000.json
+++ b/src/actors/magical-creatures-magicalcreatures/toy-soldier-toysoldier000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>A magical creature in the shape of a fifty-centimeter tall tin soldier. Toy soldiers have no intelligence of their own but follow their owner's orders completely. They are often used as guards or bodyguards for children and are deceptively tough for their size.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Toy Soldier",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761253359638,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471131,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/high-level-bandit-highlevelbandit0.json
+++ b/src/actors/npcs-npcs000000000000/high-level-bandit-highlevelbandit0.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 1",
-      "damage": "@stats.strength + 1"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 1
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 1
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>These guys are the bosses of the low-level bandits, or are bandits that live in deep forests, deserts, or other tough terrain. These bandits are well equipped to handle long journeys and target high-end goods--they may even target whole towns! Compared to weaker bandits, they possess a sharp wit, and are known for stealing hearts as well as gold. Those that live in the jungle are called \"junglers\", while those that reside in the desert are known as \"desert vikings\".</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "High-level Bandit",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254178985,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471121,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/high-level-magician-highlevelmagicia.json
+++ b/src/actors/npcs-npcs000000000000/high-level-magician-highlevelmagicia.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": null,
@@ -65,7 +70,8 @@
       "value": "<p>High-level magicians know all spells of 2 different seasons as well as all low-level, 5 mid-level and 4 high- level incantation spells. These magicians are the top of their class and are comfortable using any type of magic. Without extensive knowledge of nature, it would have been impossible for them to get this far in their magical studies.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "High-level Magician",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254361377,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471122,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/hoodlum-hoodlum000000000.json
+++ b/src/actors/npcs-npcs000000000000/hoodlum-hoodlum000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": null,
@@ -65,7 +70,8 @@
       "value": "<p>These rogues stay just outside of city limits and harass travelers.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Hoodlum",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254062231,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471123,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/knight-knight0000000000.json
+++ b/src/actors/npcs-npcs000000000000/knight-knight0000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity + 2",
-      "damage": "@stats.strength + 2"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": 2
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": 2
+      }
     },
     "defense": {
       "armor": 2,
@@ -65,7 +70,8 @@
       "value": "<p>These are the elite troops of a nation, trained in the art of war. They have experience with long journeys and can be thought of as a type of Traveler.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Knight",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254275692,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471123,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/low-level-bandit-lowlevelbandit00.json
+++ b/src/actors/npcs-npcs000000000000/low-level-bandit-lowlevelbandit00.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>These mugs lurk in grasslands, wastelands, and other easy to traverse terrain, preying on caravans and doing other unsavory things. They are usually lazy, dimwitted and uncouth. Those bandits that live in the wasteland are called \"brigands\", while those that live among hills are called \"highlanders\".</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Low-level Bandit",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254108474,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471125,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/mid-level-magician-midlevelmagician.json
+++ b/src/actors/npcs-npcs000000000000/mid-level-magician-midlevelmagician.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": null,
@@ -65,7 +70,8 @@
       "value": "<p>These mages know mid-level magic: up to mid-level spells of 1 season, 6 low-level and 4 mid-level invocation spells. These wizards are powerful enough to act as tutors or teachers of young magic users. Many mid-level wizards embark on long journeys to understand the differences between the seasons.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Mid-level Magician",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254320305,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471126,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/npcs-npcs000000000000/militia-militia000000000.json
+++ b/src/actors/npcs-npcs000000000000/militia-militia000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 1,
@@ -65,7 +70,8 @@
       "value": "<p>These guys patrol and keep the peace in town.</p>"
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Militia",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254234943,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471126,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/anaconda-anaconda00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/anaconda-anaconda00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A huge snake ranging from two to ten meters in length. It likes to attack at night, so care must be taken when camping in anaconda territory.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Anaconda",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When an anaconda succeeds on an attack on a character, it automatically coils around the character's body. On that character's next turn, they must beat the anaconda at a contested [[/check check formula=\"@stats.strength + @stats.strength\"]]{[STR + STR]} check or lose their action. Every turn that an anaconda starts coiled around a character, the anaconda automatically deals [[/check damage d6]] damage.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081619,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471132,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796152367,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471132,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/basilisk-basilisk00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/basilisk-basilisk00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 10,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A humongous lizard that can grow up to twenty meters in length, basilisks are covered in brown scales with scattered dark green spots. Though they are slow and plodding predators, they possess the ability to turn living things to stone with their gaze alone. Hunters that make their living off harvesting basilisk eyes are called “basiliterns” and use veils and robes to avoid the basilisk's stare.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Basilisk",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Characters with a Condition of less than 7 who are not wearing veils or other protection, are turned to stone.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081624,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471133,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759797338591,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471133,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/chimaera-chimaera00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/chimaera-chimaera00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A curious beast with the heads of a lion, ram and a snake. They are cruel, and will hunt and kill prey even when not hungry. It was initially thought that they were created by sorcery, but modern studies indicate that they are, in fact, just another species of animal.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Chimaera",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>The lion head breathes a blue-hot flame, with Accuracy [[/check accuracy formula=\"d10 + d10\"]] and Damage [[/check damage d10]], targeting an entire area.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081631,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471135,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759797169292,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471135,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/cockatrice-cockatrice000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/cockatrice-cockatrice000000.json
@@ -21,9 +21,7 @@
     "condition": {
       "immunities": [],
       "value": 5,
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "resources": {
       "mental": {
@@ -44,8 +42,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>These beasts look like wild chickens, but have beaks with the power to turn things to stone. They can only eat the henluda plant, so keep your guard up when you come across it in the wild.</p>"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -174,6 +178,11 @@
       "system": {
         "description": {
           "value": "<p>When a character is hit by a cockatrice's attack, they suffer [[/status injury 6]] as a part of their body is turned to stone.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -188,10 +197,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081633,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471136,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759793258325,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471135,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/demoncat-demoncat00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/demoncat-demoncat00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + 1d10",
-      "damage": ""
+      "accuracy": {
+        "die1": "strength",
+        "die2": "10",
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large grey cat (up to three meters long) with two tails and possessed of a burning hatred for humans; it is said that long ago, they were placed by a god to guard a certain artifact, but when a man stole it, they turned against humans forever.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Demoncat",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Due to their multitude of tails, fangs and claws, Demoncats roll damage on successful attacks two times, taking the best result. Also, they may use two objects at once.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081637,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471139,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796919192,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471139,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/false-egg-falseegg00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/false-egg-falseegg00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A crab that can disguise itself as a large egg. It tends to stay still for long periods of time, but hunts its prey by putting its large claws together over its body, creating a smooth egg-like shape. If you find an unattended egg, you should approach with extreme caution.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "False Egg",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>If you aren't careful, a false egg will catch you unawares with its attack. At the beginning of combat, characters must roll a [INT + INT] check. Any character that fails receives a -2 penalty to Initiative.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081643,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471143,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759795805483,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471142,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/garden-tortoise-gardentortoise00.json
+++ b/src/actors/phantom-beasts-phantombeasts000/garden-tortoise-gardentortoise00.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 15,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A gigantic tortoise that prefers warm areas that can grow twenty meters large. This beast spends its time in sunny areas, nourishing the numerous plants that grow atop its shell. As the tortoise ages, its shell grows along with the number of plants and eventually becomes large enough to support its own ecosystem.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Garden Tortoise",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>One each of each type of Healing Herb grows atop the Garden Tortoise's shell.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081649,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471144,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759797428357,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471144,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/ghost-beast-ghostbeast000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/ghost-beast-ghostbeast000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>The largest carnivorous animal in the world, the Ghost Beast measures tens of meters in length (though its exact dimensions are unknown). Its exact form and details have never been confirmed. Due to its size, it does not hunt humans, but it is extremely sensitive to imbalances in the natural order. It has been known to appear near advanced human civilizations, and when it appears... humans can only flee.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Ghost Beast",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Attacks from this beast are so strong that even the mountains crack and dragons run. Anytime this creature attacks, it attacks all areas. Also, any Fumbles it rolls automatically become criticals.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081651,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471145,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759798485986,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471144,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/giant-ant-giantant00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/giant-ant-giantant00000000.json
@@ -21,9 +21,7 @@
     "condition": {
       "immunities": [],
       "value": 4,
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "resources": {
       "mental": {
@@ -44,8 +42,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>These ants are usually found near their hive and can range in size from half a meter to a full three meters in length. Their pincers are typically the length of half their body and are incredibly powerful, able to slice a man in half.</p>"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [],
   "effects": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759793089810,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471121,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/griffon-griffon000000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/griffon-griffon000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A beast with the head and wings of a hawk and the body of a lion.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Griffon",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack two times in one turn.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081655,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471146,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796366623,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471146,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/hellhound-hellhound0000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/hellhound-hellhound0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A huge black dog, weighing about 500 kg, with glowing red eyes and razor sharp claws. They are violently territorial and mark their territories with a sulfuric smell that permeates the area. The stench of rotten eggs is nearly unbearable as far away as ten kilometers.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Hellhound",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack two times in one turn.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081660,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471148,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796806063,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471147,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/high-roadrunner-highroadrunner00.json
+++ b/src/actors/phantom-beasts-phantombeasts000/high-roadrunner-highroadrunner00.json
@@ -21,9 +21,7 @@
     "condition": {
       "immunities": [],
       "value": 5,
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "resources": {
       "mental": {
@@ -44,8 +42,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>At two meters tall, this is the fastest running bird in the world. It has the ability to run at 60 km/hour for more than an hour at a time. Their population explodes during the Spring months.</p>"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [],
   "effects": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759793524699,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471122,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/hungry-mole-hungrymole000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/hungry-mole-hungrymole000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large mole (up to 4 meters long) that lives underground. This black and silver creature must eat its weight in food everyday, and will die if it goes half a day without food.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Hungry Mole",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When a Hungry Mole attacks from underground, its target receives -1 to Initiative.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081664,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471149,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796592293,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471149,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/kamaitachi-sickle-weasel-kamaitachisickle.json
+++ b/src/actors/phantom-beasts-phantombeasts000/kamaitachi-sickle-weasel-kamaitachisickle.json
@@ -21,9 +21,7 @@
     "condition": {
       "immunities": [],
       "value": 4,
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "resources": {
       "mental": {
@@ -44,8 +42,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>It is said that a kamaitachi is actually three weasels with sickle-like claws that have joined together to harass travelers. In this form, they look like a single giant weasel with huge claws. Kamaitachi are known to be wily pranksters. They chase, cut, and heal those they come across, leaving bewildered but unharmed hikers in their wake. If they are angered, however, the three weasels will simply attack.</p>"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -174,6 +178,11 @@
       "system": {
         "description": {
           "value": "<p>Kamaitachi can attack the Back Area from the Front Area.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -188,10 +197,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081666,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471150,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759793425041,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471150,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/loyal-dog-loyaldog00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/loyal-dog-loyaldog00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>One in ten thousand dogs is born with a special gift. Though they look like any other dog, these dogs are incredibly smart. It is said that these dogs understand and may even speak human languages. Their loyalty drives them to keep their owners from danger. Are you sure your faithful companion there isn't one of these Loyal Dogs?</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Loyal Dog",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When the Loyal Dog's master takes damage, the Loyal Dog can reduce the damage taken to 0, once per combat.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081677,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471153,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796433707,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471153,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/maximillion-kabuto-maximillionkabut.json
+++ b/src/actors/phantom-beasts-phantombeasts000/maximillion-kabuto-maximillionkabut.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A huge horned beetle with a thick shell. Kabuto beetle shells are prized for their beauty and command a steep price.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Maximillion Kabuto",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796980056,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471125,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/milk-maid-milkmaid00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/milk-maid-milkmaid00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "@stats.strength + @stats.dexterity",
-      "damage": "@stats.strength"
+      "accuracy": {
+        "die1": "strength",
+        "die2": "dexterity",
+        "bonus": null
+      },
+      "damage": {
+        "die": "strength",
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A cow that lives at the shallows of the sea. As no males of their species exist, sometimes a Milk Maid will take human form to visit human villages, thinking to leave a child in town. Their milk is said to be highly valuable for treating various illnesses.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Milk Maid",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>A Milk Maid can take the form of a human female, but must bathe in sea water at least once per day.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081681,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471156,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759797277395,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471155,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/mob-beast-mobbeast00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/mob-beast-mobbeast00000000.json
@@ -21,9 +21,7 @@
     "condition": {
       "immunities": [],
       "value": 3,
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "resources": {
       "mental": {
@@ -44,8 +42,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Beasts the size and shape of a small jackal. They are fairly weak alone, but are almost always encountered in large groups. It is said that hordes of tens of thousands of mob beasts have reduced cities to rubble.</p>"
@@ -69,7 +74,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "prototypeToken": {
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [],
   "effects": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759792593513,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471127,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/pegasus-pegasus000000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/pegasus-pegasus000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A horse with bid-like wings that allow it to fly freely through the skies. Pegasi share the same temperament as a normal horse and grow to the same size. They are picky eaters, preferring fresh grass and herds will travel long distances to find it. When pegasi migrate during the fall and winter months, they look like nothing more than shooting stars as thousands dart across the skies gracefully.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Pegasus",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759795335086,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471128,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/speckled-bee-speckledbee00000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/speckled-bee-speckledbee00000.json
@@ -32,13 +32,18 @@
     "condition": {
       "value": 4,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>These bees can grow to be as large as a human and live in hives dug into rocky ground. Their honey is so highly prized that some hunters specialize in procuring it. It is incredibly dangerous to do so, but a single harvest of their honey is worth enough for an entire family to live off of for an entire year.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Speckled Bee",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When a character is damaged by a Speckled Bee attack, they take an additional d6 damage that is not mitigated by Defense Points.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081705,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471164,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759795025135,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471164,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/tumbling-nest-tumblingnest0000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/tumbling-nest-tumblingnest0000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Though it appears as a large rolling ball of bits of plant matter, these several-meter-large spheres are actually created by and filled with a large number of small rats. Because the rats can't see from within the ball, they will attack the source of any loud noises.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Tumbling Nest",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When attacking, the Tumbling Nest randomly attacks one character in the Front Area and one character in the Back Area.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081711,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471166,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759797043840,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471166,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/unicorn-unicorn000000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/unicorn-unicorn000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": ""
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Unicorn",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>It is said that a unicorn's horn has the ability to cure any illness. However, a unicorn must expend an incredible amount of energy to do so, and using this ability too much places the unicorn's life in danger.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081715,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471168,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796275705,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471168,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-beasts-phantombeasts000/zordfish-zordfish00000000.json
+++ b/src/actors/phantom-beasts-phantombeasts000/zordfish-zordfish00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large fish in the shape of a sword. They grow larger the longer they live, up to eight meters long.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Zordfish",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Attacks made by Zordfish ignore Defense Points and always do full damage.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081721,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471170,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1759796669225,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471170,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/brave-bamboo-bravebamboo00000.json
+++ b/src/actors/phantom-plants-phantomplants000/brave-bamboo-bravebamboo00000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>In large bamboo deep forests, one in several tens of thousands of bamboo develop into a Brave Bamboo. These mysterious bamboo trees become mobile and move around bamboo groves on their own. It is said that Brave Bamboo have different items inside them, depending on who defeats them. Due to this legend, there is no end to those who would hunt Brave Bamboo. It is said that a barren couple that wanted a child very badly found a treasure inside one--a baby who went on to be a legend.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Brave Bamboo",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>The Brave Bamboo may, in addition to its normal attacks, also cast the magic spell @UUID[Compendium.ryuutama.spells.Item.kaguyasleylance0] (from the Spring magic list) twice per combat.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081626,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471134,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290840314,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471134,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/charming-rafflesia-charmingrafflesi.json
+++ b/src/actors/phantom-plants-phantomplants000/charming-rafflesia-charmingrafflesi.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 10,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large plant with huge flowers that thrives in hot, humid areas. It secretes an intoxicating scent that draws prey into its flower, which then closes on its prey, trapping it. The Charming Rafflesia digests its victim slowly, drawing nutrients from its flesh, but cannot digest metallic objects, which it instead spits out after the rest of the victim is digested.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Charming Rafflesia",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>At the beginning of battle, everybody involved in the battle except the Charming Rafflesia must succeed on a [SPI+SPI] with a target number of 7, or suffer [[/status muddled 6]].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081629,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471135,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290087827,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471134,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/death-grass-deathgrass000000.json
+++ b/src/actors/phantom-plants-phantomplants000/death-grass-deathgrass000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>The most dangerous plant in the grasslands, Death Grass looks like normal grass, but all the stalks in a ten meter radius around its central bud are all part of the same organism. When an animal enters this area, the Death Grass uses its blade-like leaves to kill the target, nourishing itself with the corpse. The only way to destroy this treacherous plant is by destroying the central bud.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Death Grass",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Death Grass attacks anything in range (all characters in the Front Area in battle). This attack deals [[/check damage d6]] damage, is impossible to dodge and needs no Accuracy Check.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081635,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471138,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290332212,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471137,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/earth-tiger-earthtiger000000.json
+++ b/src/actors/phantom-plants-phantomplants000/earth-tiger-earthtiger000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of mold that lives in very arid terrain. It reacts violently to moisture, and seems to grow exponentially on contact with water. When it dries out, it lays dormant until exposed to water again. If the desiccated remains of a traveler are found, chances are that an Earth Tiger is sleeping nearby.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Earth Tiger",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Any characters that are successfully hit by an Earth Tiger attack lose [[/r d6]] rations of water from water skins or barrels in the area.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081641,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471141,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290495467,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471141,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/lightstalk-lightstalk000000.json
+++ b/src/actors/phantom-plants-phantomplants000/lightstalk-lightstalk000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 13,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of tree that can grow up to sixty meters tall. It stores enough light in its leaves to shine like a beacon through cloudy weather. It is able to concentrate the light it emanates, shooting laser-like beams to protect itself. It is said that a city called Zeperion once harnessed their energy to protect the town from powerful monsters, but was destroyed by the power these plants possess.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Lightstalk",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster may attack using its laser beam with Accuracy [[/check accuracy formula=\"d10 + d10\"]] and damage [[/check damage d12]], ignoring Defense Points.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081675,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471152,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290712678,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471152,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/myconid-myconid000000000.json
+++ b/src/actors/phantom-plants-phantomplants000/myconid-myconid000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of sapient mushroom that is able to move around on its own. It looks like a giant mushroom with an umbrella-like cap that can grow a meter wide. Myconid live in humid climes, in and around trees. They communicate telepathically and sometimes trade with travelers.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Myconid",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760289449948,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471127,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/napalm-palm-napalmpalm000000.json
+++ b/src/actors/phantom-plants-phantomplants000/napalm-palm-napalmpalm000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 7,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A large palm tree that primarily grows in arid areas. Its leaves and fronds are used to make many household goods, but it has a powerful defensive mechanism in the form of a number of egg-sized seeds that explode if touched.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Napalm Palm",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack either the Front Area or the Back Area with Accuracy [[/check accuracy formula=\"d6 + d6\"]] and damage [[/check damage formula=\"d6\"]].</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081687,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471158,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760289275732,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471158,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/parasite-eggplant-parasiteeggplant.json
+++ b/src/actors/phantom-plants-phantomplants000/parasite-eggplant-parasiteeggplant.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "1d4 + 1d10",
-      "damage": "1d10"
+      "accuracy": {
+        "die1": "4",
+        "die2": "10",
+        "bonus": null
+      },
+      "damage": {
+        "die": "10",
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A parasitic eggplant that draws nutrients from its host animal. The host, in turn, benefits from a boost in their abilities, causing some people to go out of their way to become infested. The plant's seed is exceedingly rare, so many soldiers go out of their way to hunt it down.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Parasite Eggplant",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>The being that is hosting the parasite eggplant gains Max HP and MP +10, as well as a +1 bonus to Initiative, Condition, and Defense Points for as long as the eggplant is attached.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081691,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471159,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760289993660,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471159,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/plantimal-plantimal0000000.json
+++ b/src/actors/phantom-plants-phantomplants000/plantimal-plantimal0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A strange plant that is able to move about using tentacle-like roots. It continues to grow throughout its lifespan, with some growing up to ten meters in diameter. It reacts to fluctuations of moisture in the air to entangle victims and drink their fluids. Scholars believe this creature is something between a plant and an animal.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Plantimal",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290444291,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471129,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/pseudoparasol-pseudoparasol000.json
+++ b/src/actors/phantom-plants-phantomplants000/pseudoparasol-pseudoparasol000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of giant pitcher plant. Unlike other pitcher plants, most of the plant is underground. It keeps itself closed until it rains, then opens itself up for prey to enter in search of protection from the rain. Once within the pitcher, the prey is rapidly dissolved by the plant's potent digestive fluid. However, there is a type of insect that secretes a special substances that neutralizes the fluid, allowing the insect to live within the plant. It is said that certain tribes have learned to use this substance to live inside of PseudoParasols.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "PseudoParasol",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Any character hit by a PseudoParasol attack is sucked inside of its body. Once inside the body, they can't be targeted by magic.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081695,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471161,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760290554938,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471160,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/phantom-plants-phantomplants000/tyrant-rose-tyrantrose000000.json
+++ b/src/actors/phantom-plants-phantomplants000/tyrant-rose-tyrantrose000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 8,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of rose. In order to bloom, it requires the blood of animals, which it takes by wrapping its victims in its thorny brambles. It is said that if a Tyrant Rose manages to suck the blood of one hundred animals, the world's most beautiful rose will blossom.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Tyrant Rose",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>Each time this monster successfully attacks a character, it gains 3 HP.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081713,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471167,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760289924042,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471167,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/calacassa-calacassa0000000.json
+++ b/src/actors/undead-undead0000000000/calacassa-calacassa0000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>When someone throws away an item that has been used for a long time, the item may awaken with a mind of its own. One of the more common of these undead creatures is the Calacassa, an awakened umbrella. It is said that there are 919 gods that inhabit items that have been carelessly and disrespectfully discarded.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Calacassa",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292041859,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471121,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/dulahan-dulahan000000000.json
+++ b/src/actors/undead-undead0000000000/dulahan-dulahan000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Armor-clad wandering souls of ancient warriors. Most Dulahans are headless, having lost them in battle. It is said that Dulahans do not realize that they have already died, and thus they continue their fight, forever... though it seems that this is not always true.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Dulahan",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>A Dulahan can attack 3 opponents at once with a single accuracy roll. Also, anyone hit by a Dulahan suffers [[/status sickness 8]]. This effect can't be cured until the Dulahan is defeated.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081639,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471140,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292516276,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471140,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/foxphorous-foxphorous000000.json
+++ b/src/actors/undead-undead0000000000/foxphorous-foxphorous000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A creature that had a heart full of envy in its dying moment may become a Foxphorous, a type of undead that resembles a huge purple flame in the shape of a fox. It is weak to water, but its flames will instantly explode back to full strength even after being doused with water. The only way to extinguish it is with rain or the water from a river.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Foxphorous",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When a character is hit by a Foxphorous's attack, if the character is in close combat, the character must make a [SPI+SPI] check with target number of 7. If the character fails, they must spend their next turn attacking a companion in the same area. This effect lasts until the character has attacked a companion.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081645,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471143,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292133432,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471143,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/halloween-march-halloweenmarch00.json
+++ b/src/actors/undead-undead0000000000/halloween-march-halloweenmarch00.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 15,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>Though treated as a single monster, the Halloween March is actually a large number of zombies, skeletons, and other undead monsters moving together to upbeat music. It is said that anyone who sees this parade of the undead in the pale moonlight is drawn to join them. The march continues until it reaches a place the undead have strong memories of. It is known and feared in the East, known as the “Night of 100 demons.”</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Halloween March",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>The Halloween March may, once per round, use 1 special ability of any other undead monster.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081658,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471147,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292570916,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471146,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/lady-saucer-ladysaucer000000.json
+++ b/src/actors/undead-undead0000000000/lady-saucer-ladysaucer000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 9,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "1d12 + 1d20",
-      "damage": "1d12"
+      "accuracy": {
+        "die1": "12",
+        "die2": "20",
+        "bonus": null
+      },
+      "damage": {
+        "die": "12",
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A monster that is said to be an amalgamation of souls of falsely accused innocents put to death. They look like pale, female ghosts with long black hair. Nine saucers seem to hover in the air around them, under their complete control. These are not real saucers, but are a spiritual manifestation with a sort of intelligence that allows them to throw themselves at their enemies.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Lady Saucer",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>The Lady Saucer can attack nine times at once. However, those attacks become Accuracy [[/check accuracy formula=\"d6 + d6\"]] and damage [[/check damage d6]]. If a character is hit by one of these attacks, they suffer a -1 cumulative penalty to their Condition.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081670,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471151,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292462226,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471151,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/lich-lich000000000000.json
+++ b/src/actors/undead-undead0000000000/lich-lich000000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A sorcerer who presumed to seek immortality in undeath. Stories say that the ritual used to return the soul to the spellcaster's body does so imperfectly, damaging the soul in the process. A lich loses most of his living personality and becomes greedy and egotistical. Legends claim that the lich “Seleb” is the king of the undead.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Lich",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>A lich has access to all Summer spells.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081672,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471151,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292644623,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471151,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/mummy-mummy00000000000.json
+++ b/src/actors/undead-undead0000000000/mummy-mummy00000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A type of man-made undead that is often found buried near ancient ruins. The corpse of the mummy has been treated with forgotten mix of herbs and potions, creating a type of eternal life but at the cost of eternal subservience to its creator. Unlike zombies and skeletons, mummies keep most of their intelligence. In ancient times, they were used as slaves and guards, but the rites used in their creation have long been forgotten.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Mummy",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When a character is hit by a Mummy's attack, any damage is applied to both HP and MP.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081685,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471157,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292169298,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471157,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/skeleton-skeleton00000000.json
+++ b/src/actors/undead-undead0000000000/skeleton-skeleton00000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 6,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>The animated corpse of an otherwise dead creature, given unlife by a curse, black magic, or some other necromantic energy. Shambling corpses with most of their flesh intact are known as “zombies”, while corpses that have been stripped to the bone are called “skeletons”. Skeletons are much more nimble than zombies and are able to use swords and shields. Their intellect, though dim, makes them a fearsome opponent.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Skeleton",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292072722,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471130,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/thousandbones-thousandbones000.json
+++ b/src/actors/undead-undead0000000000/thousandbones-thousandbones000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>These monsters are born on scenes of great carnage or misery, battlefields where countless bodies have been buried. They are composed of thousands of bones that come together to form a 4-legged beast. It is said that hundreds of suffering souls animate and bind the bones to some evil purpose, destroying anything in its path.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Thousandbones",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>This monster can attack two times in one turn.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081709,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471165,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292287918,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471165,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/vampire-vampire000000000.json
+++ b/src/actors/undead-undead0000000000/vampire-vampire000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>A dead human that has been reanimated using foul, eldritch magic. Vampires keep the same form and intelligence as in life but are imbued with strength and a thirst for the blood of the living. Vampires fear the light of the sun, cannot cross running water, and waste away within days if they do not drink the blood of the living. They also have no reflection, making life among humans so difficult that many vampires choose to live in the form of a wolf. However, many tales speak of vampires that continue to live secretly in the same town they in which they dwelt in life.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Vampire",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>When a vampire successfully attacks a character, the vampire is healed an amount equal to the amount of damage dealt. When a vampire kills a human, the victim rises during the next night as a vampire, loyal to the vampire that killed them.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1760662081717,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471169,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760292342506,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471168,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/undead-undead0000000000/zombie-zombie0000000000.json
+++ b/src/actors/undead-undead0000000000/zombie-zombie0000000000.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 5,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "description": {
       "value": "<p>The animated corpse of an otherwise dead creature, given unlife by a curse, black magic, or some other necromantic energy. Shambling corpses with most of their flesh intact are known as “zombies”, while corpses that have been stripped to the bone are called “skeletons”. Zombies are much clumsier than skeletons, but their ability to ignore pain and damage makes them a threat.</p>"
@@ -65,7 +70,8 @@
       }
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Zombie",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [],
@@ -178,10 +182,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1760291975063,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471131,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/wild-dragons-wilddragons00000/high-level-dragon-highleveldragon0.json
+++ b/src/actors/wild-dragons-wilddragons00000/high-level-dragon-highleveldragon0.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 15,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 5,
@@ -65,7 +70,8 @@
       "value": ""
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "High-level Dragon",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>These dragons may deal their level in damage to characters in all areas, thrice per combat. This ignores Defense Points and is in addition to its normal attack.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761254942530,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471148,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254942525,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471148,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/wild-dragons-wilddragons00000/low-level-dragon-lowleveldragon00.json
+++ b/src/actors/wild-dragons-wilddragons00000/low-level-dragon-lowleveldragon00.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 11,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 3,
@@ -65,7 +70,8 @@
       "value": ""
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Low-level Dragon",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>These dragons may deal their level in damage to characters in all areas, once per combat. This ignores Defense Points and is in addition to its normal attack.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761254857641,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471152,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254857636,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471152,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/actors/wild-dragons-wilddragons00000/mid-level-dragon-midleveldragon00.json
+++ b/src/actors/wild-dragons-wilddragons00000/mid-level-dragon-midleveldragon00.json
@@ -32,9 +32,7 @@
     "condition": {
       "value": 12,
       "immunities": [],
-      "shape": {
-        "high": ""
-      }
+      "travel": false
     },
     "abilities": {
       "strength": {
@@ -51,8 +49,15 @@
       }
     },
     "attack": {
-      "accuracy": "",
-      "damage": ""
+      "accuracy": {
+        "die1": null,
+        "die2": null,
+        "bonus": null
+      },
+      "damage": {
+        "die": null,
+        "bonus": null
+      }
     },
     "defense": {
       "armor": 4,
@@ -65,7 +70,8 @@
       "value": ""
     },
     "source": {
-      "book": "Ryuutama"
+      "book": "Ryuutama",
+      "custom": ""
     }
   },
   "name": "Mid-level Dragon",
@@ -82,12 +88,9 @@
       "src": "",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -138,7 +141,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -164,7 +167,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "img": "",
   "items": [
@@ -175,6 +179,11 @@
       "system": {
         "description": {
           "value": "<p>These dragons may deal their level in damage to characters in all areas, twice per combat. This ignores Defense Points and is in addition to its normal attack.</p>"
+        },
+        "identifier": "",
+        "source": {
+          "book": "",
+          "custom": ""
         }
       },
       "img": "icons/svg/item-bag.svg",
@@ -189,10 +198,10 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.357",
         "systemId": "ryuutama",
-        "systemVersion": "1.0.0",
-        "createdTime": 1761254902809,
+        "systemVersion": "2.0.0",
+        "createdTime": 1774636471155,
         "modifiedTime": null,
         "lastModifiedBy": "ryuutama00000000"
       },
@@ -209,10 +218,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.357",
     "systemId": "ryuutama",
-    "systemVersion": "1.4.0",
-    "createdTime": 1761254902803,
+    "systemVersion": "2.0.0",
+    "createdTime": 1774636471154,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/templates/apps/attack-config/form.hbs
+++ b/templates/apps/attack-config/form.hbs
@@ -1,4 +1,22 @@
 <section>
-  {{formGroup systemFields.attack.fields.accuracy value=accuracyValue disabled=disabled placeholder=accuracyPlaceholder}}
-  {{formGroup systemFields.attack.fields.damage value=damageValue disabled=disabled placeholder=damagePlaceholder}}
+  <fieldset>
+    <legend>{{localize "RYUUTAMA.ACTOR.MONSTER.ATTACK.accuracy"}}</legend>
+
+    <div class="form-group">
+      <label>{{localize "RYUUTAMA.ACTOR.MONSTER.ATTACK.abilities"}}</label>
+      <div class="form-fields">
+        {{formInput systemFields.attack.fields.accuracy.fields.die1 value=accuracyValue1 disabled=disabled blank=accuracyPlaceholder1}}
+        {{formInput systemFields.attack.fields.accuracy.fields.die2 value=accuracyValue2 disabled=disabled blank=accuracyPlaceholder2}}
+      </div>
+    </div>
+
+    {{formGroup systemFields.attack.fields.accuracy.fields.bonus value=accuracyBonus disabled=disabled placeholder="0" rootId=rootId classes="slim"}}
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "RYUUTAMA.ACTOR.MONSTER.ATTACK.damage"}}</legend>
+    {{formGroup systemFields.attack.fields.damage.fields.die value=damageValue disabled=disabled blank=damagePlaceholder rootId=rootId classes="slim"}}
+    {{formGroup systemFields.attack.fields.damage.fields.bonus value=damageBonus disabled=disabled placeholder="0" rootId=rootId classes="slim"}}
+  </fieldset>
+
 </section>


### PR DESCRIPTION
- Implements a `CheckDie` die class.
- All checks are now constructed with 1 or 2 `CheckDie`.
- Monster data has been migrated to have an `AttackModel` embedded in `system.attack` with more structured data for accuracy and damage checks.
- Migrated actor pack.

Close #297.