### PR TITLE
Adjust `PartyData` with new custom field for its members

### DIFF
--- a/code/data/actor/_types.d.ts
+++ b/code/data/actor/_types.d.ts
@@ -1,9 +1,9 @@
 export {};
 
 import "./templates/_types";
+import { MembersCollection } from "../fields/members-field.mjs";
 import Advancement from "../advancement/advancement.mjs";
 import AttackModel from "../attack-model.mjs";
-import Collection from "@common/utils/collection.mjs";
 import CreatureData from "./templates/creature.mjs";
 import RyuutamaActor from "../../documents/actor.mjs";
 import RyuutamaItem from "../../documents/item.mjs";
@@ -35,7 +35,7 @@ declare module "./party.mjs" {
     description: {
       value: string;
     }
-    members: Collection<string, { actor: RyuutamaActor }>;
+    members: MembersCollection<string, { actor: RyuutamaActor }>;
   }
 }
 

--- a/code/data/actor/party.mjs
+++ b/code/data/actor/party.mjs
@@ -16,10 +16,7 @@ export default class PartyData extends BaseData {
       description: new SchemaField({
         value: new HTMLField(),
       }),
-      members: new TypedObjectField(
-        new SchemaField({}),
-        { validateKey: key => foundry.data.validators.isValidId(key) },
-      ),
+      members: new ryuutama.data.fields.MembersField(),
     };
   }
 
@@ -30,6 +27,27 @@ export default class PartyData extends BaseData {
     ...super.LOCALIZATION_PREFIXES,
     "RYUUTAMA.ACTOR.PARTY",
   ];
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Actor types that can be members of a party.
+   * @type {string[]}
+   */
+  static ALLOWED_MEMBER_TYPES = Object.freeze(["traveler"]);
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is a given actor valid to be a member of a party?
+   * @param {RyuutamaActor} actor
+   * @returns {boolean}
+   */
+  static validMember(actor) {
+    return (actor instanceof foundry.documents.Actor)
+      && PartyData.ALLOWED_MEMBER_TYPES.includes(actor.type)
+      && !actor.inCompendium && !actor.isToken;
+  }
 
   /* -------------------------------------------------- */
 
@@ -51,49 +69,17 @@ export default class PartyData extends BaseData {
 
   /* -------------------------------------------------- */
 
-  /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-
-    Object.defineProperty(this, "members", {
-      enumerable: true,
-      get() {
-        return Object.entries(this._source.members).reduce((acc, [id, data]) => {
-          const actor = game.actors.get(id);
-          if (this.validMember(actor)) acc.set(actor.id, { ...data, actor });
-          return acc;
-        }, new foundry.utils.Collection());
-      },
-    });
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Is a given actor valid to be a member of this party?
-   * @param {RyuutamaActor} actor
-   * @returns {boolean}
-   */
-  validMember(actor) {
-    return (actor instanceof foundry.documents.Actor) && ["traveler"].includes(actor.type)
-      && !actor.inCompendium && !actor.isToken;
-  }
-
-  /* -------------------------------------------------- */
-
   /**
    * Add members to the party.
    * @param {RyuutamaActor[]} [actors]    The actors to add.
    * @returns {Promise<RyuutamaActor>}    A promise that resolves to the updated party actor.
    */
   async addMembers(actors = []) {
-    actors = new Set(actors.filter(this.validMember)).filter(actor => !this.members.has(actor.id));
-    const ids = [...this.members.keys(), ...actors.map(a => a.id)];
-    const update = Object.entries(this.toObject().members).reduce((acc, [id, src]) => {
-      if (ids.includes(id)) acc[id] = src;
-      return acc;
-    }, {});
-    ids.forEach(id => update[id] = {});
+    const update = Object.fromEntries(this.members.map(m => [m.actor.id, this._source.members[m.actor.id]]));
+    actors.forEach(actor => {
+      if (!PartyData.validMember(actor) || (actor.id in update)) return;
+      update[actor.id] = {};
+    });
     await this.parent.update({ "system.members": _replace(update) });
     return this.parent;
   }
@@ -106,11 +92,9 @@ export default class PartyData extends BaseData {
    * @returns {Promise<RyuutamaActor>}    A promise that resolves to the updated party actor.
    */
   async removeMembers(actors = []) {
-    const update = {};
-    actors.forEach(actor => {
-      if (this.validMember(actor) && this.members.has(actor.id)) update[actor.id] = _del;
-    });
-    await this.parent.update({ "system.members": update });
+    const update = Object.fromEntries(this.members.actors.map(a => [a.id, this._source.members[a.id]]));
+    actors.forEach(actor => delete update[actor.id]);
+    await this.parent.update({ "system.members": _replace(update) });
     return this.parent;
   }
 

--- a/code/data/fields/_module.mjs
+++ b/code/data/fields/_module.mjs
@@ -3,5 +3,6 @@ export { default as EquipmentField } from "./equipment-field.mjs";
 export { default as FormulaField } from "./formula-field.mjs";
 export { default as IdentifierField } from "./identifier-field.mjs";
 export { default as LocalDocumentField } from "./local-document-field.mjs";
+export { default as MembersField } from "./members-field.mjs";
 export { default as SourceField } from "./source-field.mjs";
 export { default as TypedRecordField } from "./typed-record-field.mjs";

--- a/code/data/fields/members-field.mjs
+++ b/code/data/fields/members-field.mjs
@@ -1,0 +1,73 @@
+/**
+ * @import { DataFieldContext, TypedObjectFieldOptions } from "@common/data/_types.mjs";
+ * @import Collection from "@common/utils/collection.mjs";
+ * @import RyuutamaActor from "../../documents/actor.mjs";
+ */
+
+const { SchemaField, TypedObjectField } = foundry.data.fields;
+
+/**
+ * A subclass of TypedObjectField that initializes as a getter for party members.
+ */
+export default class MembersField extends TypedObjectField {
+  /**
+   * @param {TypedObjectFieldOptions} [options]
+   * @param {DataFieldContext} [context]
+   */
+  constructor(options = {}, context = {}) {
+    const validateKey = key => foundry.data.validators.isValidId(key);
+    super(new SchemaField({}), { ...options, validateKey }, context);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  initialize(value, model, options = {}) {
+    if (!value) return value;
+    const object = super.initialize(value, model, options);
+    return () => Object.entries(object).reduce((acc, [id, data]) => {
+      const actor = game.actors.get(id);
+      if (ryuutama.data.actor.PartyData.validMember(actor)) acc.set(actor.id, { ...data, actor });
+      return acc;
+    }, new MembersCollection());
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Specialized collection for members of a party.
+ * @template {string} K;
+ * @template {{ actor: RyuutamaActor }} V
+ * @extends {foundry.utils.Collection<K, V>}
+ */
+export class MembersCollection extends foundry.utils.Collection {
+  /**
+   * The actors in the party.
+   * @type {Collection<string, RyuutamaActor>}
+   */
+  get actors() {
+    return this.reduce((acc, { actor }) => acc.set(actor.id, actor), new foundry.utils.Collection());
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The members organized by type.
+   * @type {Record<string, { actor: RyuutamaActor }>|null}
+   */
+  #documentsByType = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The members organized by type.
+   * @type {Record<string, { actor: RyuutamaActor }>}
+   */
+  get documentsByType() {
+    if (this.#documentsByType) return this.#documentsByType;
+    const entries = Object.fromEntries(ryuutama.data.actor.PartyData.ALLOWED_MEMBER_TYPES.map(type => [type, []]));
+    this.forEach(m => entries[m.actor._source.type].push(m));
+    return this.#documentsByType = entries;
+  }
+}


### PR DESCRIPTION
Using `initialize` to instantiate a getter means not having to override the value in `prepareBaseData`.