### PR TITLE
[#341] Implement water capacity

### DIFF
--- a/code/config.mjs
+++ b/code/config.mjs
@@ -214,6 +214,7 @@ export const containerProperties = {
     label: "RYUUTAMA.ITEM.CONTAINER.PROPERTIES.waterContainer",
   },
 };
+Prelocalization.prelocalize(containerProperties);
 
 /* -------------------------------------------------- */
 

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -202,6 +202,22 @@ Prelocalization.prelocalize(checkTypes.journey.subtypes);
 /* -------------------------------------------------- */
 
 /**
+ * @typedef ContainerPropertyConfig
+ * @property {string} label   Human-readable label.
+ */
+
+/**
+ * @type {Record<string, ContainerPropertyConfig>}
+ */
+export const containerProperties = {
+  waterContainer: {
+    label: "RYUUTAMA.ITEM.CONTAINER.PROPERTIES.waterContainer",
+  },
+};
+
+/* -------------------------------------------------- */
+
+/**
  * @typedef DamageRollPropertyConfig
  * @property {string} label       Human-readable label.
  * @property {string} icon        Icon displayed in chat messages for this property.

--- a/code/constants.mjs
+++ b/code/constants.mjs
@@ -49,6 +49,17 @@ toConfig(ANIMAL_TYPES, "animalTypes");
 /* -------------------------------------------------- */
 
 /**
+ * Properties for containers.
+ * @enum {string}
+ */
+export const CONTAINER_PROPERTIES = {
+  WATER_CONTAINER: "waterContainer",
+};
+toConfig(CONTAINER_PROPERTIES, "containerProperties");
+
+/* -------------------------------------------------- */
+
+/**
  * Herb types.
  * @enum {string}
  */

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -351,8 +351,13 @@ export default class TravelerData extends CreatureData {
       const size = item.system.weight ?? 0;
       capacity.value += size;
 
-      if (["animal", "container"].includes(item.type)) {
-        capacity.container += item.system.capacity.max;
+      switch (item.type) {
+        case "animal":
+          capacity.container += item.system.capacity.total;
+          break;
+        case "container":
+          capacity.container += item.system.capacity.total;
+          break;
       }
     });
 

--- a/code/data/item/_types.d.ts
+++ b/code/data/item/_types.d.ts
@@ -57,15 +57,21 @@ declare module "./class.mjs" {
 declare module "./container.mjs" {
   export default interface ContainerData {
     capacity: {
-      max: number;
+      max: number | null;
+      water: number | null;
+      value: number;
+      total: number | null;
+      pct: number;
     }
     price: {
       value: number;
     }
+    properties: Set<"waterContainer">;
     rations: Record<string, { type: string, modifier?: string }>;
     size: {
       value: 1 | 3 | 5;
     }
+    weight: number;
   }
 }
 

--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -55,6 +55,8 @@ export default class AnimalData extends BaseData {
   prepareDerivedData() {
     super.prepareDerivedData();
 
+    this.capacity.total = this.capacity.max;
+
     this.#preparePrice();
     this.#prepareCategory();
     this.#prepareModifierLabels();

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -4,7 +4,7 @@ import BaseData from "./templates/base.mjs";
  * @import RyuutamaItem from "../../documents/item.mjs";
  */
 
-const { NumberField, SchemaField, StringField, TypedObjectField, TypedSchemaField } = foundry.data.fields;
+const { NumberField, SchemaField, SetField, StringField, TypedObjectField, TypedSchemaField } = foundry.data.fields;
 
 export default class ContainerData extends BaseData {
   /** @inheritdoc */
@@ -24,10 +24,12 @@ export default class ContainerData extends BaseData {
     return Object.assign(super.defineSchema(), {
       capacity: new SchemaField({
         max: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
+        water: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
       }),
       price: new SchemaField({
         value: new NumberField({ nullable: false, initial: 1, min: 0, integer: true }),
       }),
+      properties: new SetField(new StringField({ choices: ryuutama.CONST.CONTAINER_PROPERTIES._toConfig })),
       rations: new TypedObjectField(
         new TypedSchemaField(rationTypes()),
         { validateKey: key => foundry.data.validators.isValidId(key) },
@@ -54,20 +56,13 @@ export default class ContainerData extends BaseData {
 
   /* -------------------------------------------------- */
 
-  /**
-   * The amount this adds to the capacity.
-   * @type {number}
-   */
-  get weight() {
-    return this.size.total + Object.keys(this.rations).length;
-  }
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
     this.size.total = this.size.value;
+    this.capacity.value = 0;
+
+    const isWaterContainer = this.properties.has("waterContainer");
 
     Object.defineProperties(this.rations, Object.values(ryuutama.CONST.RATION_TYPES).reduce((acc, k) => {
       acc[k] = {
@@ -90,7 +85,14 @@ export default class ContainerData extends BaseData {
           return label;
         },
       });
-      this.rations[r.type].push(r);
+
+      const display = isWaterContainer
+        ? r.type === ryuutama.CONST.RATION_TYPES.WATER
+        : r.type !== ryuutama.CONST.RATION_TYPES.WATER;
+      if (display) {
+        this.rations[r.type].push(r);
+        this.capacity.value++;
+      }
     }
 
     const m = {
@@ -105,6 +107,12 @@ export default class ContainerData extends BaseData {
         return a - b;
       });
     }
+
+    this.capacity.total = isWaterContainer ? this.capacity.water : this.capacity.max;
+    this.capacity.pct = Math.clamp(Math.round(this.capacity.value / this.capacity.total * 100), 0, 100) || 0;
+
+    // The amount this adds to a Traveler's capacity.
+    this.weight = this.size.total + this.capacity.value;
   }
 
   /* -------------------------------------------------- */
@@ -115,9 +123,15 @@ export default class ContainerData extends BaseData {
       rations: {},
     };
     Object.values(ryuutama.CONST.RATION_TYPES).forEach(type => {
+      const entries = sheet.document.system.rations[type];
       ctx.rations[type] = {
-        entries: sheet.document.system.rations[type],
+        entries,
+        display: this.properties.has("waterContainer")
+          ? (type === ryuutama.CONST.RATION_TYPES.WATER)
+          : (type !== ryuutama.CONST.RATION_TYPES.WATER),
         label: ryuutama.config.rationTypes[type].label,
+        disableDown: !entries.length || !context.editable,
+        disableUp: !context.editable || ((this.capacity.pct === 100) && (this.capacity.total !== null)),
       };
     });
   }

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -142,9 +142,11 @@ export default class ContainerData extends BaseData {
   _prepareTooltipContext(context, options = {}) {
     super._prepareTooltipContext(context, options);
 
+    const isWaterContainer = this.properties.has("waterContainer");
+    const formula = `${this.capacity.value} / ${this.capacity.total}`;
     context.tagSections.push({
       tags: [
-        { label: _loc("RYUUTAMA.TOOLTIP.capacity", { formula: this.capacity.max }) },
+        { label: _loc(isWaterContainer ? "RYUUTAMA.TOOLTIP.waterCapacity" : "RYUUTAMA.TOOLTIP.capacity", { formula }) },
       ],
     });
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -599,7 +599,11 @@
 
       "CONTAINER": {
         "FIELDS": {
-          "capacity.max.label": "Can Hold"
+          "capacity.max.label": "Item Capacity",
+          "capacity.water.label": "Water Capacity"
+        },
+        "PROPERTIES": {
+          "waterContainer": "Water Container"
         },
         "capacity": "Capacity"
       },

--- a/lang/en.json
+++ b/lang/en.json
@@ -900,7 +900,8 @@
       "range": "Range: {formula}",
       "riders": "Riders: {formula}",
       "target": "Target: {formula}",
-      "terrain": "Terrain: {label}"
+      "terrain": "Terrain: {label}",
+      "waterCapacity": "Water Capacity: {formula}"
     },
 
     "WEATHER": {

--- a/src/items/containers-containers000000/_folder.json
+++ b/src/items/containers-containers000000/_folder.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Containers",
+  "color": "#456cba",
+  "sorting": "a",
+  "_id": "containers000000",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776285068407,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!containers000000"
+}

--- a/src/items/containers-containers000000/belt-pouch-beltpouch0000000.json
+++ b/src/items/containers-containers000000/belt-pouch-beltpouch0000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "containers000000",
+  "name": "Belt Pouch",
+  "type": "container",
+  "_id": "beltpouch0000000",
+  "img": "icons/containers/bags/satchel-leather-grey.webp",
+  "system": {
+    "description": {
+      "value": "<p>Only one can be equipped. Good when you want to be able to grab something quickly.</p>"
+    },
+    "identifier": "belt-pouch",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 2,
+      "water": null
+    },
+    "price": {
+      "value": 30
+    },
+    "rations": {},
+    "size": {
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945480,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!beltpouch0000000"
+}

--- a/src/items/containers-containers000000/big-containers-bigcontainers000/_folder.json
+++ b/src/items/containers-containers000000/big-containers-bigcontainers000/_folder.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "containers000000",
+  "name": "Big Containers",
+  "color": "#38558f",
+  "sorting": "a",
+  "_id": "bigcontainers000",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776285494239,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!bigcontainers000"
+}

--- a/src/items/containers-containers000000/big-containers-bigcontainers000/backpack-backpack00000000.json
+++ b/src/items/containers-containers000000/big-containers-bigcontainers000/backpack-backpack00000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "bigcontainers000",
+  "name": "Backpack",
+  "type": "container",
+  "_id": "backpack00000000",
+  "img": "icons/containers/bags/pack-leather-strapped-tan.webp",
+  "system": {
+    "description": {
+      "value": "<p>A rucksack used by many travelers.</p>"
+    },
+    "identifier": "backpack",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 5,
+      "water": null
+    },
+    "price": {
+      "value": 20
+    },
+    "rations": {},
+    "size": {
+      "value": 3
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945479,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!backpack00000000"
+}

--- a/src/items/containers-containers000000/big-containers-bigcontainers000/barrel-barrel0000000000.json
+++ b/src/items/containers-containers000000/big-containers-bigcontainers000/barrel-barrel0000000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "bigcontainers000",
+  "name": "Barrel",
+  "type": "container",
+  "_id": "barrel0000000000",
+  "img": "icons/containers/barrels/barrel-apple-steel-orange.webp",
+  "system": {
+    "description": {
+      "value": "<p>Holds 15 days worth of water, or holds 10 size worth of other items.</p>"
+    },
+    "identifier": "barrel",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 10,
+      "water": 15
+    },
+    "price": {
+      "value": 10
+    },
+    "rations": {},
+    "size": {
+      "value": 5
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945479,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!barrel0000000000"
+}

--- a/src/items/containers-containers000000/big-containers-bigcontainers000/large-backpack-largebackpack000.json
+++ b/src/items/containers-containers000000/big-containers-bigcontainers000/large-backpack-largebackpack000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "bigcontainers000",
+  "name": "Large Backpack",
+  "type": "container",
+  "_id": "largebackpack000",
+  "img": "icons/containers/bags/pack-simple-stitched-leather-tan.webp",
+  "system": {
+    "description": {
+      "value": "<p>Large rucksack that holds many items.</p>"
+    },
+    "identifier": "large-backpack",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 10,
+      "water": null
+    },
+    "price": {
+      "value": 40
+    },
+    "rations": {},
+    "size": {
+      "value": 5
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945486,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!largebackpack000"
+}

--- a/src/items/containers-containers000000/big-containers-bigcontainers000/wooden-chest-woodenchest00000.json
+++ b/src/items/containers-containers000000/big-containers-bigcontainers000/wooden-chest-woodenchest00000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "bigcontainers000",
+  "name": "Wooden Chest",
+  "type": "container",
+  "_id": "woodenchest00000",
+  "img": "icons/containers/chest/chest-reinforced-box-brown.webp",
+  "system": {
+    "description": {
+      "value": "<p>If carried by a human, they take a -1 penalty to Travel Checks.</p>"
+    },
+    "identifier": "wooden-chest",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 15,
+      "water": null
+    },
+    "price": {
+      "value": 10
+    },
+    "rations": {},
+    "size": {
+      "value": 5
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945491,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!woodenchest00000"
+}

--- a/src/items/containers-containers000000/herb-bottle-herbbottle000000.json
+++ b/src/items/containers-containers000000/herb-bottle-herbbottle000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "containers000000",
+  "name": "Herb Bottle",
+  "type": "container",
+  "_id": "herbbottle000000",
+  "img": "icons/containers/kitchenware/vase-bottle-brown.webp",
+  "system": {
+    "description": {
+      "value": "<p>Magically keeps up to ten herbs fresh; once opened for the first time, the bottle is good for seven days before it no longer works.</p>"
+    },
+    "identifier": "herb-bottle",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": null,
+      "water": null
+    },
+    "price": {
+      "value": 100
+    },
+    "rations": {},
+    "size": {
+      "value": 3
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945485,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!herbbottle000000"
+}

--- a/src/items/containers-containers000000/magic-jar-magicjar00000000.json
+++ b/src/items/containers-containers000000/magic-jar-magicjar00000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "containers000000",
+  "name": "Magic Jar",
+  "type": "container",
+  "_id": "magicjar00000000",
+  "img": "icons/containers/kitchenware/vase-clay-painted-brown-white.webp",
+  "system": {
+    "description": {
+      "value": "<p>A magical jar that keeps cold liquids cold or hot liquids hot: +1 Travel Checks while in hot/cold weather.</p>"
+    },
+    "identifier": "magic-jar",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": null,
+      "water": null
+    },
+    "price": {
+      "value": 2000
+    },
+    "rations": {},
+    "size": {
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945487,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!magicjar00000000"
+}

--- a/src/items/containers-containers000000/travel-bag-travelbag0000000.json
+++ b/src/items/containers-containers000000/travel-bag-travelbag0000000.json
@@ -1,0 +1,46 @@
+{
+  "folder": "containers000000",
+  "name": "Travel Bag",
+  "type": "container",
+  "_id": "travelbag0000000",
+  "img": "icons/containers/bags/coinpouch-leather-grey.webp",
+  "system": {
+    "description": {
+      "value": "<p>A bag held in 1 hand.</p>"
+    },
+    "identifier": "travel-bag",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": 3,
+      "water": null
+    },
+    "price": {
+      "value": 10
+    },
+    "rations": {},
+    "size": {
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945490,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!travelbag0000000"
+}

--- a/src/items/containers-containers000000/waterskin-waterskin0000000.json
+++ b/src/items/containers-containers000000/waterskin-waterskin0000000.json
@@ -1,0 +1,50 @@
+{
+  "folder": "containers000000",
+  "name": "Waterskin",
+  "type": "container",
+  "_id": "waterskin0000000",
+  "img": "icons/containers/bags/pack-simple-leather-fur-tan.webp",
+  "system": {
+    "description": {
+      "value": "<p>A pouch of leather that can hold a day's ration of water.</p>"
+    },
+    "identifier": "waterskin",
+    "source": {
+      "book": "Ryuutama",
+      "custom": ""
+    },
+    "capacity": {
+      "max": null,
+      "water": 1
+    },
+    "price": {
+      "value": 30
+    },
+    "rations": {
+      "waterration00000": {
+        "type": "water"
+      }
+    },
+    "size": {
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1776287945490,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!waterskin0000000"
+}

--- a/templates/sheets/item-sheet/container.hbs
+++ b/templates/sheets/item-sheet/container.hbs
@@ -1,22 +1,26 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
   {{!-- PRICE --}}
-  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder="1" rootId=rootId}}
+  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1" rootId=rootId}}
 
   {{!-- CONTAINER SIZE --}}
   {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled classes="slim" rootId=rootId}}
 
   {{!-- CAPACITY --}}
+  {{formGroup systemFields.properties value=(ifThen disabled document.system.properties source.system.properties) disabled=disabled type="checkboxes" localize=true classes="stacked"}}
   {{formGroup systemFields.capacity.fields.max value=(ifThen disabled document.system.capacity.max source.system.capacity.max) disabled=disabled placeholder="-" classes="slim" rootId=rootId}}
+  {{formGroup systemFields.capacity.fields.water value=(ifThen disabled document.system.capacity.water source.system.capacity.water) disabled=disabled placeholder="-" classes="slim" rootId=rootId}}
 
   {{!-- RATIONS --}}
   {{#each container.rations as |rations type|}}
+  {{#if display}}
   <div class="form-group slim" data-ration-type="{{type}}">
     <span>{{rations.label}}</span>
     <div class="form-fields">
-      <button type="button" data-action="decreaseRation" class="icon fa-solid fa-minus" {{disabled (not @root.editable)}}></button>
+      <a data-action="decreaseRation" class="fa-solid fa-minus" {{disabled rations.disableDown}}></a>
       <span>{{rations.entries.length}}</span>
-      <button type="button" data-action="increaseRation" class="icon fa-solid fa-plus" {{disabled (not @root.editable)}}></button>
+      <a data-action="increaseRation" class="fa-solid fa-plus" {{disabled rations.disableUp}}></a>
     </div>
   </div>
+  {{/if}}
   {{/each}}
 </section>

--- a/templates/sheets/item-sheet/container.hbs
+++ b/templates/sheets/item-sheet/container.hbs
@@ -6,7 +6,7 @@
   {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled classes="slim" rootId=rootId}}
 
   {{!-- CAPACITY --}}
-  {{formGroup systemFields.properties value=(ifThen disabled document.system.properties source.system.properties) disabled=disabled type="checkboxes" localize=true classes="stacked"}}
+  {{formGroup systemFields.properties value=(ifThen disabled document.system.properties source.system.properties) disabled=disabled type="checkboxes" classes="stacked"}}
   {{formGroup systemFields.capacity.fields.max value=(ifThen disabled document.system.capacity.max source.system.capacity.max) disabled=disabled placeholder="-" classes="slim" rootId=rootId}}
   {{formGroup systemFields.capacity.fields.water value=(ifThen disabled document.system.capacity.water source.system.capacity.water) disabled=disabled placeholder="-" classes="slim" rootId=rootId}}
 


### PR DESCRIPTION
- Implements `ContainerData#properties: Set<"waterContainer">`.
- Renames the 'Can Hold' field to 'Item Capacity' (`ContainerData#capacity.max`).
- Adds a 'Water Capacity' field (`ContainerData#capacity.water`).
- Disables the ration up/down buttons depending on remaining capacity of the container.
- The capacity a container adds to an actor is now equal to `ContainerData#capacity.total` which is either `ContainerData#capacity.water` or `CapacityData#capacity.max`. Also added `AnimalData#capacity.total` to mirror this.
- If a container is a Water Container, its food/rations/animal feed is entirely ignored and cannot be edited on the Container item sheet.
- If a container is not a Water Container, its water rations are entirely ignored and cannot be edited on the Container item sheet.

Closes #341.

<img width="870" height="504" alt="image" src="https://github.com/user-attachments/assets/b203d3cc-4255-4f9e-b006-2cb6a12750c5" />