### PR TITLE
Improve item tooltips

### DIFF
--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -98,6 +98,8 @@ export default class AnimalData extends BaseData {
 
     this.capacity.riders = this.capacity.canRide ? (this.capacity.riders ?? config.ride) : null;
     this.capacity.max = this.capacity.canCarry ? (this.capacity.max ?? config.capacity) : null;
+
+    this.category.label = config.label;
   }
 
   /* -------------------------------------------------- */
@@ -139,5 +141,21 @@ export default class AnimalData extends BaseData {
     // Animal capacity details.
     const { ride, capacity } = ryuutama.config.animalTypes[this.category.value];
     context.animal = { defaultRiding: ride, defaultCapacity: capacity };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.typeTag = this.category.label;
+    const section = {
+      tags: [
+        this.capacity.max ? { label: _loc("RYUUTAMA.TOOLTIP.capacity", { formula: this.capacity.max }) } : null,
+        this.capacity.riders ? { label: _loc("RYUUTAMA.TOOLTIP.riders", { formula: this.capacity.riders }) } : null,
+      ].filter(_ => _),
+    };
+    if (section.tags.length) context.tagSections.push(section);
   }
 }

--- a/code/data/item/armor.mjs
+++ b/code/data/item/armor.mjs
@@ -53,4 +53,16 @@ export default class ArmorData extends PhysicalData {
     this.armor.defense = this._source.armor.defense + bonus;
     if (this.modifiers.has("mythril") && (this.armor.penalty > 0)) this.armor.penalty = this._source.armor.penalty - 1;
   }
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.tagSections.push({
+      tags: [
+        this.armor.defense ? { label: _loc("RYUUTAMA.TOOLTIP.defense", { formula: this.armor.defense }) } : null,
+        this.armor.penalty ? { label: _loc("RYUUTAMA.TOOLTIP.penalty", { formula: this.armor.penalty }) } : null,
+      ].filter(_ => _),
+    });
+  }
 }

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -124,6 +124,19 @@ export default class ContainerData extends BaseData {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.tagSections.push({
+      tags: [
+        { label: _loc("RYUUTAMA.TOOLTIP.capacity", { formula: this.capacity.max }) },
+      ],
+    });
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Add new rations.
    * @param {number} [quantity=1]   Number of rations of the type to add.

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -87,6 +87,7 @@ export default class HerbData extends BaseData {
     }
 
     this.terrain.label = this.#prepareTerrainLabel();
+    this.category.label = ryuutama.config.herbTypes[this.category.value].label;
   }
 
   /* -------------------------------------------------- */
@@ -132,5 +133,20 @@ export default class HerbData extends BaseData {
     }
     context.herbTypes = herbTypes;
     context.herbLevelOptions = herbLevelOptions;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.tagSections.push({
+      tags: [
+        { label: _loc("RYUUTAMA.TOOLTIP.terrain", { label: this.terrain.label }) },
+      ],
+    });
+
+    context.typeTag = `${_loc("TYPES.Item.herb")} (${this.category.label})`;
   }
 }

--- a/code/data/item/shield.mjs
+++ b/code/data/item/shield.mjs
@@ -55,4 +55,19 @@ export default class ShieldData extends PhysicalData {
     this.armor.dodge = this._source.armor.dodge + bonus;
     if (this.modifiers.has("mythril") && (this.armor.penalty > 0)) this.armor.penalty = this._source.armor.penalty - 1;
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.tagSections.push({
+      tags: [
+        this.armor.defense ? { label: _loc("RYUUTAMA.TOOLTIP.defense", { formula: this.armor.defense }) } : null,
+        this.armor.penalty ? { label: _loc("RYUUTAMA.TOOLTIP.penalty", { formula: this.armor.penalty }) } : null,
+        this.armor.dodge ? { label: _loc("RYUUTAMA.TOOLTIP.dodge", { formula: this.armor.dodge }) } : null,
+      ].filter(_ => _),
+    });
+  }
 }

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -134,4 +134,23 @@ export default class SpellData extends BaseData {
         };
       });
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+
+    context.tagSections.push({
+      tags: [
+        this.spell.costLabel ? { label: this.spell.costLabel } : null,
+        this.spell.activation.cast === "ritual" ? { label: this.spell.activation.label } : null,
+        { label: _loc("RYUUTAMA.TOOLTIP.duration", { formula: this.spell.duration.label }) },
+        { label: _loc("RYUUTAMA.TOOLTIP.range", { formula: this.spell.range.label }) },
+        this.spell.target.label ? { label: _loc("RYUUTAMA.TOOLTIP.target", { formula: this.spell.target.label }) } : null,
+      ].filter(_ => _),
+    });
+
+    context.typeTag = `${ryuutama.config.spellLevels[this.spell.level].label} (${ryuutama.config.spellCategories[this.category.value].label})`;
+  }
 }

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -79,13 +79,19 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
    * @returns {Promise<HTMLElement[]>}
    */
   async richTooltip() {
-    const enriched = await CONFIG.ux.TextEditor.enrichHTML(this.description.value, {
-      rollData: this.parent.getRollData(), relativeTo: this.parent,
-    });
+    const rollData = this.parent.getRollData();
+    const enriched = await CONFIG.ux.TextEditor.enrichHTML(this.description.value, { rollData, relativeTo: this.parent });
+
     const context = {
       item: this.parent,
       enriched,
+      rollData,
+      tagSections: [],
+      typeTag: _loc(`TYPES.Item.${this.parent.type}`),
     };
+
+    this._prepareTooltipContext(context);
+
     const htmlString = await foundry.applications.handlebars.renderTemplate(
       "systems/ryuutama/templates/ui/items/tooltip.hbs",
       context,
@@ -94,6 +100,21 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
     const div = document.createElement("DIV");
     div.innerHTML = htmlString;
     return div.children;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare subtype specific context for tooltips.
+   * @param {object} context
+   * @param {object} [options]
+   */
+  _prepareTooltipContext(context, options = {}) {
+    if (this.modifierLabels?.length) {
+      context.tagSections.push({
+        tags: this.modifierLabels.map(label => ({ label })),
+      });
+    }
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/weapon.mjs
+++ b/code/data/item/weapon.mjs
@@ -141,4 +141,25 @@ export default class WeaponData extends PhysicalData {
     rollData.isMastered = this.isMastered;
     return rollData;
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareTooltipContext(context, options = {}) {
+    super._prepareTooltipContext(context, options);
+    context.tagSections.push({
+      tags: [
+        { label: _loc("RYUUTAMA.TOOLTIP.accuracy", { formula: this.accuracy.label }) },
+        { label: _loc("RYUUTAMA.TOOLTIP.damage", { formula: this.damage.label }) },
+      ],
+    });
+
+    if (this.parent.isEmbedded) {
+      context.tagSections.push({
+        tags: [{ label: this.isMastered ? _loc("RYUUTAMA.TOOLTIP.mastered") : _loc("RYUUTAMA.TOOLTIP.notMastered") }],
+      });
+    }
+
+    context.typeTag = `${_loc("TYPES.Item.weapon")} (${this.category.label})`;
+  }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -883,6 +883,22 @@
       "highlands": "Highlands"
     },
 
+    "TOOLTIP": {
+      "accuracy": "Accuracy: {formula}",
+      "capacity": "Capacity: {formula}",
+      "damage": "Damage: {formula}",
+      "defense": "Defense: {formula}",
+      "dodge": "Dodge: {formula}",
+      "duration": "Duration: {formula}",
+      "mastered": "Mastered",
+      "notMastered": "Not Mastered",
+      "penalty": "Penalty: {formula}",
+      "range": "Range: {formula}",
+      "riders": "Riders: {formula}",
+      "target": "Target: {formula}",
+      "terrain": "Terrain: {label}"
+    },
+
     "WEATHER": {
       "blizzard": "Blizzard",
       "clearSkies": "Clear Skies",

--- a/styles/ui/tooltips.css
+++ b/styles/ui/tooltips.css
@@ -23,6 +23,19 @@
 
   .tooltip-name {
     margin: 0;
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+    font-size: 20px;
+    border-bottom: 1px solid var(--ryuutama-enriched-tooltip-border);
+    text-align: center;
+  }
+
+  .tooltip-type {
+    font-style: italic;
+  }
+
+  .tooltip-content {
+    margin: 1rem;
   }
 
   section.tooltip-tags {

--- a/templates/ui/items/tooltip.hbs
+++ b/templates/ui/items/tooltip.hbs
@@ -1,43 +1,13 @@
 <section class="tooltip item" {{#if item.actor}} data-actor-uuid="{{item.actor.uuid}}" {{/if}}>
   <h4 class="tooltip-name">{{item.name}}</h4>
+  <span class="tooltip-type">{{typeTag}}</span>
   <section class="tooltip-content">{{{enriched}}}</section>
 
-  {{#if item.system.modifierLabels.length}}
-  <section class="tooltip-modifiers tooltip-tags">
-    {{#each item.system.modifierLabels}}
-    <div class="tooltip-tag">{{this}}</div>
+  {{#each tagSections}}
+  <section class="tooltip-tags">
+    {{#each tags}}
+    <div class="tooltip-tag">{{label}}</div>
     {{/each}}
   </section>
-  {{/if}}
-
-  {{!-- WEAPON --}}
-  {{#if (eq item.type "weapon")}}
-  <section class="tooltip-tags">
-    <div class="tooltip-tag">{{item.system.category.label}}</div>
-    <div class="tooltip-tag">{{item.system.accuracy.label}}</div>
-    <div class="tooltip-tag">{{item.system.damage.label}}</div>
-  </section>
-  {{/if}}
-
-  {{!-- HERB --}}
-  {{#if item.system.terrain.label}}
-  <section class="tooltip-tags">
-    <div class="tooltip-tag">{{item.system.terrain.label}}</div>
-  </section>
-  {{/if}}
-
-  {{!-- SPELL --}}
-  {{#if (eq item.type "spell")}}
-  <section class="tooltip-tags">
-    {{#if item.system.spell.costLabel}}
-    <div class="tooltip-tag">{{item.system.spell.costLabel}}</div>
-    {{/if}}
-    <div class="tooltip-tag">{{item.system.spell.activation.label}}</div>
-    <div class="tooltip-tag">{{item.system.spell.duration.label}}</div>
-    <div class="tooltip-tag">{{item.system.spell.range.label}}</div>
-    {{#if item.system.spell.target.label}}
-    <div class="tooltip-tag">{{item.system.spell.target.label}}</div>
-    {{/if}}
-  </section>
-  {{/if}}
+  {{/each}}
 </section>


### PR DESCRIPTION
Minor refactor of the item tooltips, allowing item subtypes to generate "tag sections" and other context.

Each item type displays additional tags such as modifiers, defense, capacity, etc.