### PR TITLE
[#4] Implement drag-drop logic, datafields, and rendering, for containers

### DIFF
--- a/code/applications/api/document-sheet.mjs
+++ b/code/applications/api/document-sheet.mjs
@@ -157,7 +157,7 @@ export default class RyuutamaDocumentSheet extends HandlebarsApplicationMixin(Do
 
     // Set up drag-drop.
     this._dragDrop ??= new CONFIG.ux.DragDrop({
-      dragSelector: ".document-listing .document-list .entry",
+      dragSelector: ".document-listing .document-list .entry, [data-drag-start]",
       dropSelector: null,
       permissions: {
         dragstart: RyuutamaDocumentSheet._canDragstart.bind(this),

--- a/code/applications/apps/compendium-browser.mjs
+++ b/code/applications/apps/compendium-browser.mjs
@@ -130,6 +130,7 @@ export default class RyuutamaCompendiumBrowser extends HandlebarsApplicationMixi
     ],
     Item: [
       "system.category.value", // spell category, herb category
+      "system.container",
       "system.identifier",
       "system.source.book",
       "system.source.custom",
@@ -331,10 +332,15 @@ export default class RyuutamaCompendiumBrowser extends HandlebarsApplicationMixi
       .map(([name]) => name);
     if (!methods.length) return new Set();
 
-    const match = entry => methods.every(name => RyuutamaCompendiumBrowser.FILTERS[name].callback(entry, filters));
+    const match = (entry, pack) => {
+      if (pack.index.has(entry.system.container)) return false;
+      return methods.every(name => RyuutamaCompendiumBrowser.FILTERS[name].callback(entry, filters));
+    };
+
     const matches = Object.entries(RyuutamaCompendiumBrowser.ENTRIES[documentName]).reduce((acc, [pack, entries]) => {
-      if (!game.packs.get(pack).visible) return acc;
-      return acc.concat(entries.filter(match));
+      pack = game.packs.get(pack);
+      if (!pack.visible) return acc;
+      return acc.concat(entries.filter(entry => match(entry, pack)));
     }, []);
 
     if (indexOnly) return new Set(matches);

--- a/code/applications/apps/compendium-browser.mjs
+++ b/code/applications/apps/compendium-browser.mjs
@@ -130,12 +130,12 @@ export default class RyuutamaCompendiumBrowser extends HandlebarsApplicationMixi
     ],
     Item: [
       "system.category.value", // spell category, herb category
-      "system.container",
       "system.identifier",
       "system.source.book",
       "system.source.custom",
       "system.spell.activation.cast",
       "system.spell.level",
+      "system.storage",
     ],
   };
 
@@ -333,7 +333,7 @@ export default class RyuutamaCompendiumBrowser extends HandlebarsApplicationMixi
     if (!methods.length) return new Set();
 
     const match = (entry, pack) => {
-      if (pack.index.has(entry.system.container)) return false;
+      if (pack.index.has(entry.system.storage)) return false;
       return methods.every(name => RyuutamaCompendiumBrowser.FILTERS[name].callback(entry, filters));
     };
 

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -2,6 +2,7 @@ import RyuutamaBaseActorSheet from "./base.mjs";
 
 /**
  * @import RyuutamaActor from "../../../documents/actor.mjs";
+ * @import RyuutamaItem from "../../../documents/item.mjs";
  */
 
 /**
@@ -17,6 +18,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     },
     actions: {
       adjustFumbles: RyuutamaTravelerSheet.#adjustFumbles,
+      changeInventoryView: RyuutamaTravelerSheet.#changeInventoryView,
       toggleEffect: RyuutamaTravelerSheet.#toggleEffect,
     },
   };
@@ -132,6 +134,26 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       ],
     },
   };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The inventory being viewed, either `null` if viewing the actor's direct inventory,
+   * or the id of an item that can store contents.
+   * @type {string|null}
+   */
+  #inventoryView = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The active storage item whose inventory is being viewed.
+   * @type {RyuutamaItem|null}
+   */
+  get activeContainer() {
+    const item = this.document.items.get(this.#inventoryView);
+    return item ? item : null;
+  }
 
   /* -------------------------------------------------- */
 
@@ -538,7 +560,6 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
    * @returns {{ search: object, groups: object[], containers: object[] }}
    */
   #prepareInventory(context) {
-    const catMode = this.search.currentCategorizationMode("inventory");
 
     const makeDur = item => {
       const id = `${context.rootId}-${item.id}-durability`;
@@ -575,18 +596,33 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       return buttons;
     };
 
-    const inContainer = item => {
-      return ryuutama.data.fields.ContainerField.getContainer(item);
+    const activeContainer = this.activeContainer;
+
+    // Is an item visible on the character sheet by being in the current container view?
+    const inView = item => {
+      const parent = ryuutama.data.fields.ContainerField.getContainer(item);
+      if (activeContainer) return parent === activeContainer;
+      else return !parent;
+    };
+
+    const itemCollection = activeContainer
+      ? Object.groupBy(activeContainer.system.contents, item => item.type)
+      : this.document.items.documentsByType;
+
+    const makeLabel = type => {
+      let label = type ? _loc(`TYPES.Item.${type}Pl`) : _loc("DOCUMENT.Items");
+      if (activeContainer) return `${label} (${activeContainer.name})`;
+      return label;
     };
 
     const makeSection = (type, props = true) => {
-      const items = this.document.items.documentsByType[type].filter(item => !inContainer(item));
-      if (!items.length) return null;
+      const items = itemCollection[type]?.filter(item => inView(item));
+      if (!items?.length) return null;
       const durability = props && CONFIG.Item.dataModels[type].schema.has("durability");
       return {
         sort: CONFIG.Item.dataModels[type].metadata.sort,
         durability,
-        labelPlural: _loc(`TYPES.Item.${type}Pl`),
+        labelPlural: makeLabel(type),
         attributeLabel: durability ? _loc("RYUUTAMA.ACTOR.durability") : null,
         items: items.map(item => ({
           document: item,
@@ -600,19 +636,26 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     const menuOptions = [];
     const groups = [];
     const sortMode = this.search.currentSortMode("inventory");
+    const catMode = this.search.currentCategorizationMode("inventory");
 
-    for (const type of Object.keys(CONFIG.Item.dataModels)) {
+    for (const type of getDocumentClass("Item").TYPES) {
       if (type === CONST.BASE_DOCUMENT_TYPE) continue;
-      if (!CONFIG.Item.dataModels[type].metadata?.inventory) continue;
+      if (!CONFIG.Item.dataModels[type]?.metadata?.inventory) continue;
 
+      // Menu options are made regardless of container view.
       menuOptions.push(makeMenuOption(type));
+
       if (catMode === ryuutama.applications.ux.RyuutamaSearchManager.CATEGORIZATION_MODES.GROUPED) {
         const section = makeSection(type);
         if (section) groups.push(section);
       } else {
-        if (!groups.length) groups.push({ labelPlural: _loc("DOCUMENT.Items"), items: [] });
-        for (const item of this.document.items.documentsByType[type]) {
-          if (inContainer(item)) continue;
+        if (!groups.length) groups.push({
+          labelPlural: makeLabel(),
+          items: [],
+        });
+
+        for (const item of itemCollection[type] ?? []) {
+          if (!inView(item)) continue;
           groups[0].items.push({
             document: item,
             dataset: { "item-context": "" },
@@ -651,11 +694,18 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     };
 
     const containers = [];
-    this.document.items.documentsByType.container.forEach(item => {
-      containers.push({ item });
+    ["container", "animal"].forEach(type => {
+      this.document.items.documentsByType[type].forEach(item => {
+        containers.push({ item, sort: item.sort, active: item === activeContainer });
+      });
     });
-    this.document.items.documentsByType.animal.forEach(item => {
-      containers.push({ item });
+    containers.sort((a, b) => {
+      switch (sortMode) {
+        case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.ALPHABETIC:
+          return a.item.name.localeCompare(b.item.name);
+        case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.MANUAL:
+          return a.sort - b.sort;
+      }
     });
 
     return { search, groups, containers };
@@ -860,7 +910,20 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
 
     // Equip the item if dropped onto the equipment section.
     if (toEquip) {
-      await this.document.update({ [`system.equipped.${item.type}`]: item.id });
+      await foundry.documents.modifyBatch([
+        {
+          action: "update",
+          parent: this.document.parent,
+          documentName: "Actor",
+          updates: [{ _id: this.document.id, [`system.equipped.${item.type}`]: item.id }],
+        },
+        {
+          action: "update",
+          parent: this.document,
+          documentName: "Item",
+          updates: [{ _id: item.id, "system.container": null }],
+        },
+      ]);
       return true;
     }
 
@@ -872,8 +935,25 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       return true;
     }
 
-    // Dropping an item from this actor's container should move it out.
-    if (ryuutama.data.fields.ContainerField.getContainer(item)?.actor === this.document) {
+    // Dropping an item from this actor's containers should move it out or to different container.
+    const parent = ryuutama.data.fields.ContainerField.getContainer(item);
+    if (parent?.actor === this.document) {
+      // If dropping onto the Inventory section, add to active container, otherwise move out of container.
+      if (event.target?.closest("[data-search-container='inventory']")) {
+        // Dropping onto self. Sort contents.
+        if (this.activeContainer === parent) {
+          await this._onSortItem(event, item);
+          return true;
+        }
+
+        // Dropping onto different container's view, add to that container.
+        if (this.activeContainer) {
+          await item.update({ "system.container": this.activeContainer.id });
+          return true;
+        }
+      }
+
+      // Otherwise, simply move the contents out of the container.
       await item.update({ "system.container": null });
       return true;
     }
@@ -901,6 +981,19 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
    * @this RyuutamaTravelerSheet
    * @param {PointerEvent} event    The initiating click event.
    * @param {HTMLElement} target    The capturing element that defined the [data-action].
+   */
+  static #changeInventoryView(event, target) {
+    const id = target.closest("[data-uuid]").dataset.uuid.split(".").at(-1);
+    this.#inventoryView = this.#inventoryView === id ? null : id;
+    this.render();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaTravelerSheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
    */
   static #toggleEffect(event, target) {
     const effect = this.getEmbeddedDocument(target.closest("[data-uuid]").dataset.uuid);

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -609,7 +609,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
 
     // Is an item visible on the character sheet by being in the current container view?
     const inView = item => {
-      const parent = ryuutama.data.fields.ContainerField.getContainer(item);
+      const parent = ryuutama.data.fields.StorageField.getParentStorage(item);
       if (activeContainer) return parent === activeContainer;
       else return !parent;
     };
@@ -927,14 +927,14 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
           action: "update",
           parent: this.document,
           documentName: "Item",
-          updates: [{ _id: item.id, "system.container": null }],
+          updates: [{ _id: item.id, "system.storage": null }],
         },
       ]);
       return true;
     }
 
     // Dropping a container from elsewhere.
-    if (item.system.isContainer && (item.parent !== this.document)) {
+    if (item.system.isStorage && (item.parent !== this.document)) {
       const Item = getDocumentClass("Item");
       const itemData = await Item.createWithContents([item]);
       await Item.createDocuments(itemData, { parent: this.document, keepId: true });
@@ -942,7 +942,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     }
 
     // Dropping an item from this actor's containers should move it out or to different container.
-    const parent = ryuutama.data.fields.ContainerField.getContainer(item);
+    const parent = ryuutama.data.fields.StorageField.getParentStorage(item);
     if (parent?.actor === this.document) {
       // If dropping onto the Inventory section, add to active container, otherwise move out of container.
       if (event.target?.closest("[data-search-container='inventory']")) {
@@ -954,13 +954,13 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
 
         // Dropping onto different container's view, add to that container.
         if (this.activeContainer) {
-          await item.update({ "system.container": this.activeContainer.id });
+          await item.update({ "system.storage": this.activeContainer.id });
           return true;
         }
       }
 
       // Otherwise, simply move the contents out of the container.
-      await item.update({ "system.container": null });
+      await item.update({ "system.storage": null });
       return true;
     }
 

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -560,6 +560,17 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
    * @returns {{ search: object, groups: object[], containers: object[] }}
    */
   #prepareInventory(context) {
+    const activeContainer = this.activeContainer;
+
+    const itemCollection = activeContainer
+      ? Object.groupBy(activeContainer.system.contents, item => item.type)
+      : this.document.items.documentsByType;
+
+    const menuOptions = [];
+    const groups = [];
+    const sortMode = this.search.currentSortMode("inventory");
+    const catMode = this.search.currentCategorizationMode("inventory");
+    const containers = [];
 
     const makeDur = item => {
       const id = `${context.rootId}-${item.id}-durability`;
@@ -596,8 +607,6 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       return buttons;
     };
 
-    const activeContainer = this.activeContainer;
-
     // Is an item visible on the character sheet by being in the current container view?
     const inView = item => {
       const parent = ryuutama.data.fields.ContainerField.getContainer(item);
@@ -605,10 +614,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       else return !parent;
     };
 
-    const itemCollection = activeContainer
-      ? Object.groupBy(activeContainer.system.contents, item => item.type)
-      : this.document.items.documentsByType;
-
+    // Make label for a section with (or without) item subtype.
     const makeLabel = type => {
       let label = type ? _loc(`TYPES.Item.${type}Pl`) : _loc("DOCUMENT.Items");
       if (activeContainer) return `${label} (${activeContainer.name})`;
@@ -633,55 +639,70 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       };
     };
 
-    const menuOptions = [];
-    const groups = [];
-    const sortMode = this.search.currentSortMode("inventory");
-    const catMode = this.search.currentCategorizationMode("inventory");
-
-    for (const type of getDocumentClass("Item").TYPES) {
-      if (type === CONST.BASE_DOCUMENT_TYPE) continue;
-      if (!CONFIG.Item.dataModels[type]?.metadata?.inventory) continue;
-
-      // Menu options are made regardless of container view.
-      menuOptions.push(makeMenuOption(type));
-
-      if (catMode === ryuutama.applications.ux.RyuutamaSearchManager.CATEGORIZATION_MODES.GROUPED) {
-        const section = makeSection(type);
-        if (section) groups.push(section);
-      } else {
-        if (!groups.length) groups.push({
-          labelPlural: makeLabel(),
-          items: [],
-        });
-
-        for (const item of itemCollection[type] ?? []) {
-          if (!inView(item)) continue;
-          groups[0].items.push({
-            document: item,
-            dataset: { "item-context": "" },
-            buttons: makeButtons(item),
-          });
-        }
-      }
-    }
-
-    groups.sort((a, b) => {
-      const sort = a.sort - b.sort;
-      if (sort) return sort;
-      return a.labelPlural.localeCompare(b.labelPlural);
-    });
-
-    for (const group of groups) group.items.sort((a, b) => {
+    // Sorting method for groups and containers.
+    const sortGroup = (a, b) => {
       switch (sortMode) {
         case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.ALPHABETIC:
           return a.document.name.localeCompare(b.document.name);
         case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.MANUAL:
           return a.document.sort - b.document.sort;
       }
+    };
+
+    const makeGroupedSection = type => {
+      const section = makeSection(type);
+      if (section) groups.push(section);
+    };
+
+    const makeUngroupedSection = type => {
+      if (!groups.length) groups.push({ labelPlural: makeLabel(), items: [] });
+
+      itemCollection[type]?.forEach(item => {
+        if (!inView(item)) return;
+        groups[0].items.push({
+          document: item,
+          dataset: { "item-context": "" },
+          buttons: makeButtons(item),
+        });
+      });
+    };
+
+    const iterateItemType = type => {
+      if (type === CONST.BASE_DOCUMENT_TYPE) return;
+      if (!CONFIG.Item.dataModels[type]?.metadata?.inventory) return;
+
+      // Menu options are made regardless of container view.
+      menuOptions.push(makeMenuOption(type));
+
+      switch (catMode) {
+        case ryuutama.applications.ux.RyuutamaSearchManager.CATEGORIZATION_MODES.GROUPED:
+          return makeGroupedSection(type);
+        default:
+          return makeUngroupedSection(type);
+      }
+    };
+
+    // Set up all the sections.
+    getDocumentClass("Item").TYPES.forEach(iterateItemType);
+
+    // Set up container section.
+    ["container", "animal"].forEach(type => {
+      this.document.items.documentsByType[type].forEach(item => {
+        containers.push({ document: item, active: item === activeContainer });
+      });
     });
 
+    // Sort all the groups and menu options.
+    groups.sort((a, b) => {
+      const sort = a.sort - b.sort;
+      if (sort) return sort;
+      return a.labelPlural.localeCompare(b.labelPlural);
+    });
     menuOptions.sort((a, b) => a.sort - b.sort);
+    groups.forEach(group => group.items.sort(sortGroup));
+    containers.sort(sortGroup);
 
+    // Set up search.
     const key = "inventory";
     const search = {
       key,
@@ -692,21 +713,6 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       expanded: this.expandedFilters.has(key),
       options: menuOptions,
     };
-
-    const containers = [];
-    ["container", "animal"].forEach(type => {
-      this.document.items.documentsByType[type].forEach(item => {
-        containers.push({ item, sort: item.sort, active: item === activeContainer });
-      });
-    });
-    containers.sort((a, b) => {
-      switch (sortMode) {
-        case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.ALPHABETIC:
-          return a.item.name.localeCompare(b.item.name);
-        case ryuutama.applications.ux.RyuutamaSearchManager.SORT_MODES.MANUAL:
-          return a.sort - b.sort;
-      }
-    });
 
     return { search, groups, containers };
   }

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -575,8 +575,12 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       return buttons;
     };
 
+    const inContainer = item => {
+      return ryuutama.data.fields.ContainerField.getContainer(item);
+    };
+
     const makeSection = (type, props = true) => {
-      const items = this.document.items.documentsByType[type];
+      const items = this.document.items.documentsByType[type].filter(item => !inContainer(item));
       if (!items.length) return null;
       const durability = props && CONFIG.Item.dataModels[type].schema.has("durability");
       return {
@@ -608,6 +612,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       } else {
         if (!groups.length) groups.push({ labelPlural: _loc("DOCUMENT.Items"), items: [] });
         for (const item of this.document.items.documentsByType[type]) {
+          if (inContainer(item)) continue;
           groups[0].items.push({
             document: item,
             dataset: { "item-context": "" },
@@ -848,6 +853,20 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     // Equip the item if dropped onto the equipment section.
     if (toEquip) {
       await this.document.update({ [`system.equipped.${item.type}`]: item.id });
+      return true;
+    }
+
+    // Dropping a container from elsewhere.
+    if ((item.type === "container") && (item.parent !== this.document)) {
+      const Item = getDocumentClass("Item");
+      const itemData = await Item.createWithContents([item]);
+      await Item.createDocuments(itemData, { parent: this.document, keepId: true });
+      return true;
+    }
+
+    // Dropping an item from this actor's container should move it out.
+    if (ryuutama.data.fields.ContainerField.getContainer(item)?.actor === this.document) {
+      await item.update({ "system.container": null });
       return true;
     }
 

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -535,7 +535,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
   /**
    * Prepare inventory sections.
    * @param {object} context    Rendering context.
-   * @returns {{ search: object, groups: object[] }}
+   * @returns {{ search: object, groups: object[], containers: object[] }}
    */
   #prepareInventory(context) {
     const catMode = this.search.currentCategorizationMode("inventory");
@@ -650,7 +650,15 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
       options: menuOptions,
     };
 
-    return { search, groups };
+    const containers = [];
+    this.document.items.documentsByType.container.forEach(item => {
+      containers.push({ item });
+    });
+    this.document.items.documentsByType.animal.forEach(item => {
+      containers.push({ item });
+    });
+
+    return { search, groups, containers };
   }
 
   /* -------------------------------------------------- */

--- a/code/applications/sheets/actors/traveler.mjs
+++ b/code/applications/sheets/actors/traveler.mjs
@@ -857,7 +857,7 @@ export default class RyuutamaTravelerSheet extends RyuutamaBaseActorSheet {
     }
 
     // Dropping a container from elsewhere.
-    if ((item.type === "container") && (item.parent !== this.document)) {
+    if (item.system.isContainer && (item.parent !== this.document)) {
       const Item = getDocumentClass("Item");
       const itemData = await Item.createWithContents([item]);
       await Item.createDocuments(itemData, { parent: this.document, keepId: true });

--- a/code/applications/sheets/items/item-sheet.mjs
+++ b/code/applications/sheets/items/item-sheet.mjs
@@ -250,7 +250,7 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
         onClick: (event, target) => getContainedItem(target).then(item => {
           item.update({ "system.container": null });
         }),
-        visible: target => (this.document.type === "container") && this.isEditable,
+        visible: target => this.document.system.isContainer && this.isEditable,
         group: "system",
       },
     ];
@@ -273,8 +273,8 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
       return true;
     }
 
-    // Dropping a physical item onto a Container item sheet.
-    if (item.system.schema.has("container") && (this.document.type === "container")) {
+    // Dropping a physical item onto a container item sheet.
+    if (item.system.schema.has("container") && this.document.system.isContainer) {
       // Case 1: The two items are in the same collection.
       if (item.collection.has(this.document.id)) {
         await item.update({ "system.container": this.document.id });

--- a/code/applications/sheets/items/item-sheet.mjs
+++ b/code/applications/sheets/items/item-sheet.mjs
@@ -165,6 +165,13 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
       ".document-listing .document-list .entry[data-document-name=ActiveEffect]",
       { hookName: "Get{}ActiveEffectContextOptions", parentClassHooks: false, fixed: true },
     );
+
+    // Manage a container's contents.
+    this._createContextMenu(
+      RyuutamaItemSheet.#createItemContextOptions.bind(this),
+      ".document-listing .document-list .entry[data-document-name=Item]",
+      { hookName: "get{}ItemContextOptions", parentClassHooks: false, fixed: true },
+    );
   }
 
   /* -------------------------------------------------- */
@@ -210,17 +217,83 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Create context menu options for items.
+   * @this RyuutamaItemSheet
+   * @returns {ContextMenuEntry[]}
+   */
+  static #createItemContextOptions() {
+    const getContainedItem = target => fromUuid(target.closest("[data-uuid]").dataset.uuid);
+
+    return [
+      {
+        label: "RYUUTAMA.ITEM.CONTEXT.ITEM.view",
+        icon: "fa-solid fa-eye",
+        onClick: (event, target) => getContainedItem(target).then(item => item.sheet.render({ force: true, mode: 1 })),
+      },
+      {
+        label: "RYUUTAMA.ITEM.CONTEXT.ITEM.edit",
+        icon: "fa-solid fa-edit",
+        onClick: (event, target) => getContainedItem(target).then(item => item.sheet.render({ force: true, mode: 0 })),
+      },
+      {
+        label: "RYUUTAMA.ITEM.CONTEXT.ITEM.delete",
+        icon: "fa-solid fa-trash",
+        onClick: (event, target) => getContainedItem(target).then(item => {
+          item.deleteDialog({ renderOptions: { window: { windowId: this.window.windowId } } });
+        }),
+        visible: target => this.isEditable,
+      },
+      {
+        label: "RYUUTAMA.ITEM.CONTEXT.ITEM.remove",
+        icon: "fa-solid fa-hand",
+        onClick: (event, target) => getContainedItem(target).then(item => {
+          item.update({ "system.container": null });
+        }),
+        visible: target => (this.document.type === "container") && this.isEditable,
+        group: "system",
+      },
+    ];
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   async _onDropItem(event, item) {
     const target = event.target;
+
+    // Dropping a Skill item onto a Class item sheet.
     const isSkillDrop = target.classList.contains("droparea")
       && (this.document.type === "class")
       && (item.type === "skill");
-    if (!isSkillDrop) return super._onDropItem(event, item);
-    await this.document.update({
-      "system.skills": this.document.system.toObject().skills.concat({ uuid: item.uuid }),
-    });
-    return true;
+    if (isSkillDrop) {
+      await this.document.update({
+        "system.skills": this.document.system.toObject().skills.concat({ uuid: item.uuid }),
+      });
+      return true;
+    }
+
+    // Dropping a physical item onto a Container item sheet.
+    if (item.system.schema.has("container") && (this.document.type === "container")) {
+      // Case 1: The two items are in the same collection.
+      if (item.collection.has(this.document.id)) {
+        await item.update({ "system.container": this.document.id });
+        return true;
+      }
+
+      // Case 2: Owned or unowned container, and an item from elsewhere.
+      else {
+        const { pack, parent } = this.document;
+        const keepId = !this.document.collection.has(item.id);
+        const itemData = game.items.fromCompendium(item, { clearFolder: true, keepId });
+        foundry.utils.setProperty(itemData, "system.container", this.document.id);
+        foundry.utils.setProperty(itemData, "folder", this.document.folder?.id);
+        await getDocumentClass("Item").create(itemData, { pack, parent, keepId });
+        return true;
+      }
+    }
+
+    return super._onDropItem(event, item);
   }
 
   /* -------------------------------------------------- */

--- a/code/applications/sheets/items/item-sheet.mjs
+++ b/code/applications/sheets/items/item-sheet.mjs
@@ -248,9 +248,9 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
         label: "RYUUTAMA.ITEM.CONTEXT.ITEM.remove",
         icon: "fa-solid fa-hand",
         onClick: (event, target) => getContainedItem(target).then(item => {
-          item.update({ "system.container": null });
+          item.update({ "system.storage": null });
         }),
-        visible: target => this.document.system.isContainer && this.isEditable,
+        visible: target => this.document.system.isStorage && this.isEditable,
         group: "system",
       },
     ];
@@ -274,10 +274,10 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
     }
 
     // Dropping a physical item onto a container item sheet.
-    if (item.system.schema.has("container") && this.document.system.isContainer) {
+    if (item.system.schema.has("storage") && !item.system.isStorage && this.document.system.isStorage) {
       // Case 1: The two items are in the same collection.
       if (item.collection.has(this.document.id)) {
-        await item.update({ "system.container": this.document.id });
+        await item.update({ "system.storage": this.document.id });
         return true;
       }
 
@@ -286,7 +286,7 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
         const { pack, parent } = this.document;
         const keepId = !this.document.collection.has(item.id);
         const itemData = game.items.fromCompendium(item, { clearFolder: true, keepId });
-        foundry.utils.setProperty(itemData, "system.container", this.document.id);
+        foundry.utils.setProperty(itemData, "system.storage", this.document.id);
         foundry.utils.setProperty(itemData, "folder", this.document.folder?.id);
         await getDocumentClass("Item").create(itemData, { pack, parent, keepId });
         return true;

--- a/code/applications/sidebar/_module.mjs
+++ b/code/applications/sidebar/_module.mjs
@@ -1,1 +1,2 @@
+export * as apps from "./apps/_module.mjs";
 export * as tabs from "./tabs/_module.mjs";

--- a/code/applications/sidebar/apps/_module.mjs
+++ b/code/applications/sidebar/apps/_module.mjs
@@ -1,0 +1,1 @@
+export { default as RyuutamaItemCompendium } from "./item-compendium.mjs";

--- a/code/applications/sidebar/apps/item-compendium.mjs
+++ b/code/applications/sidebar/apps/item-compendium.mjs
@@ -19,7 +19,7 @@ export default class RyuutamaItemCompendium extends foundry.applications.sidebar
 
   /** @inheritdoc */
   async _createDroppedEntry(entry, updates = {}) {
-    if (entry.type !== "container") return super._createDroppedEntry(entry, updates);
+    if (!entry.system.isContainer) return super._createDroppedEntry(entry, updates);
 
     const Item = getDocumentClass("Item");
     const itemData = await Item.createWithContents([entry]);

--- a/code/applications/sidebar/apps/item-compendium.mjs
+++ b/code/applications/sidebar/apps/item-compendium.mjs
@@ -11,7 +11,7 @@ export default class RyuutamaItemCompendium extends foundry.applications.sidebar
     }
 
     items.forEach(item => {
-      if (items.has(item.system?.container)) this.element?.querySelector(`[data-entry-id="${item._id}"]`)?.remove();
+      if (items.has(item.system?.storage)) this.element?.querySelector(`[data-entry-id="${item._id}"]`)?.remove();
     });
   }
 
@@ -19,7 +19,7 @@ export default class RyuutamaItemCompendium extends foundry.applications.sidebar
 
   /** @inheritdoc */
   async _createDroppedEntry(entry, updates = {}) {
-    if (!entry.system.isContainer) return super._createDroppedEntry(entry, updates);
+    if (!entry.system.isStorage) return super._createDroppedEntry(entry, updates);
 
     const Item = getDocumentClass("Item");
     const itemData = await Item.createWithContents([entry]);
@@ -36,9 +36,9 @@ export default class RyuutamaItemCompendium extends foundry.applications.sidebar
 
     if (!this._entryAlreadyExists(entry)) return super._handleDroppedEntry(target, data);
 
-    const container = await ryuutama.data.fields.ContainerField.getContainer(entry);
+    const container = await ryuutama.data.fields.StorageField.getParentStorage(entry);
     if (!container || !this._entryAlreadyExists(container)) return super._handleDroppedEntry(target, data);
 
-    await entry.update({ "system.container": null });
+    await entry.update({ "system.storage": null });
   }
 }

--- a/code/applications/sidebar/apps/item-compendium.mjs
+++ b/code/applications/sidebar/apps/item-compendium.mjs
@@ -1,0 +1,44 @@
+export default class RyuutamaItemCompendium extends foundry.applications.sidebar.apps.Compendium {
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    let items = this.collection;
+    if (this.collection.index) {
+      if (!this.collection._reindexing) this.collection._reindexing = this.collection.getIndex();
+      await this.collection._reindexing;
+      items = this.collection.index;
+    }
+
+    items.forEach(item => {
+      if (items.has(item.system?.container)) this.element?.querySelector(`[data-entry-id="${item._id}"]`)?.remove();
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _createDroppedEntry(entry, updates = {}) {
+    if (entry.type !== "container") return super._createDroppedEntry(entry, updates);
+
+    const Item = getDocumentClass("Item");
+    const itemData = await Item.createWithContents([entry]);
+    const [container] = await Item.createDocuments(itemData, { pack: this.collection.metadata.id, keepId: true });
+    return container;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _handleDroppedEntry(target, data) {
+    let entry = await this._getDroppedEntryFromData(data);
+    if (!entry) return;
+
+    if (!this._entryAlreadyExists(entry)) return super._handleDroppedEntry(target, data);
+
+    const container = await ryuutama.data.fields.ContainerField.getContainer(entry);
+    if (!container || !this._entryAlreadyExists(container)) return super._handleDroppedEntry(target, data);
+
+    await entry.update({ "system.container": null });
+  }
+}

--- a/code/applications/sidebar/tabs/_module.mjs
+++ b/code/applications/sidebar/tabs/_module.mjs
@@ -1,3 +1,4 @@
 export { default as RyuutamaActorDirectory } from "./actors.mjs";
 export { default as RyuutamaCombatTracker } from "./combats.mjs";
 export { default as RyuutamaCompendiumDirectory } from "./compendium.mjs";
+export { default as RyuutamaItemDirectory } from "./items.mjs";

--- a/code/applications/sidebar/tabs/items.mjs
+++ b/code/applications/sidebar/tabs/items.mjs
@@ -1,0 +1,26 @@
+/**
+ * An extension of the items sidebar for Container functionality.
+ */
+export default class RyuutamaItemDirectory extends foundry.applications.sidebar.tabs.ItemDirectory {
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    this.element.querySelectorAll("[data-entry-id]").forEach(element => {
+      const item = game.items.get(element.dataset.entryId);
+      if (ryuutama.data.fields.ContainerField.getContainer(item)) element.remove();
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _createDroppedEntry(entry, updates = {}) {
+    if (entry.type !== "container") return super._createDroppedEntry(entry, updates);
+
+    const Item = getDocumentClass("Item");
+    const itemData = await Item.createWithContents([entry]);
+    const [container] = await Item.createDocuments(itemData, { keepId: true });
+    return container;
+  }
+}

--- a/code/applications/sidebar/tabs/items.mjs
+++ b/code/applications/sidebar/tabs/items.mjs
@@ -8,7 +8,7 @@ export default class RyuutamaItemDirectory extends foundry.applications.sidebar.
 
     this.element.querySelectorAll("[data-entry-id]").forEach(element => {
       const item = game.items.get(element.dataset.entryId);
-      if (ryuutama.data.fields.ContainerField.getContainer(item)) element.remove();
+      if (ryuutama.data.fields.StorageField.getParentStorage(item)) element.remove();
     });
   }
 
@@ -16,7 +16,7 @@ export default class RyuutamaItemDirectory extends foundry.applications.sidebar.
 
   /** @inheritdoc */
   async _createDroppedEntry(entry, updates = {}) {
-    if (!entry.system.isContainer) return super._createDroppedEntry(entry, updates);
+    if (!entry.system.isStorage) return super._createDroppedEntry(entry, updates);
 
     const Item = getDocumentClass("Item");
     const itemData = await Item.createWithContents([entry]);

--- a/code/applications/sidebar/tabs/items.mjs
+++ b/code/applications/sidebar/tabs/items.mjs
@@ -16,7 +16,7 @@ export default class RyuutamaItemDirectory extends foundry.applications.sidebar.
 
   /** @inheritdoc */
   async _createDroppedEntry(entry, updates = {}) {
-    if (entry.type !== "container") return super._createDroppedEntry(entry, updates);
+    if (!entry.system.isContainer) return super._createDroppedEntry(entry, updates);
 
     const Item = getDocumentClass("Item");
     const itemData = await Item.createWithContents([entry]);

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -349,7 +349,6 @@ export default class TravelerData extends CreatureData {
     const techBonus = this.details.type.technical;
 
     capacity.value = 0;
-    capacity.container = 0;
     this.parent.items.forEach(item => {
       // Equipped items do not add to capacity.
       if (equipped[item.type] === item) return;
@@ -359,12 +358,6 @@ export default class TravelerData extends CreatureData {
 
       const size = item.system.weight ?? 0;
       capacity.value += size;
-
-      switch (item.type) {
-        case "animal":
-          capacity.container += item.system.capacity.total;
-          break;
-      }
     });
 
     capacity.max =
@@ -372,8 +365,7 @@ export default class TravelerData extends CreatureData {
       + 3
       + capacity.bonus
       + (details.level - 1)
-      + techBonus * 3
-      + capacity.container;
+      + techBonus * 3;
 
     capacity.penalty = Math.max(0, capacity.value - capacity.max);
     capacity.pct = Math.clamp(Math.round(capacity.value / capacity.max * 100), 0, 100);

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -351,15 +351,17 @@ export default class TravelerData extends CreatureData {
     capacity.value = 0;
     capacity.container = 0;
     this.parent.items.forEach(item => {
+      // Equipped items do not add to capacity.
       if (equipped[item.type] === item) return;
+
+      // Items in containers do not add to capacity.
+      if (ryuutama.data.fields.ContainerField.getContainer(item)) return;
+
       const size = item.system.weight ?? 0;
       capacity.value += size;
 
       switch (item.type) {
         case "animal":
-          capacity.container += item.system.capacity.total;
-          break;
-        case "container":
           capacity.container += item.system.capacity.total;
           break;
       }

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -272,11 +272,15 @@ export default class TravelerData extends CreatureData {
     this.equipped.orichalcum = 0;
 
     for (const item of this.equipped) {
-      if (!item.system.isUsable) continue;
-      if (!item.system.isEquippable) {
+      if (ryuutama.data.fields.StorageField.getParentStorage(item)) {
+        // The item is in storage, cannot be equipped.
         Object.defineProperty(this.equipped, item.type, { value: null });
         continue;
       }
+
+      // Broken weapon cannot add to cursed/orichalcum count.
+      if (!item.system.isUsable) continue;
+
       if (item.system.modifiers.has("cursed")) this.equipped.cursed++;
       if (item.system.modifiers.has("orichalcum")) this.equipped.orichalcum++;
     }
@@ -354,7 +358,7 @@ export default class TravelerData extends CreatureData {
       if (equipped[item.type] === item) return;
 
       // Items in containers do not add to capacity.
-      if (ryuutama.data.fields.ContainerField.getContainer(item)) return;
+      if (ryuutama.data.fields.StorageField.getParentStorage(item)) return;
 
       const size = item.system.weight ?? 0;
       capacity.value += size;

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -273,6 +273,10 @@ export default class TravelerData extends CreatureData {
 
     for (const item of this.equipped) {
       if (!item.system.isUsable) continue;
+      if (!item.system.isEquippable) {
+        Object.defineProperty(this.equipped, item.type, { value: null });
+        continue;
+      }
       if (item.system.modifiers.has("cursed")) this.equipped.cursed++;
       if (item.system.modifiers.has("orichalcum")) this.equipped.orichalcum++;
     }

--- a/code/data/fields/_module.mjs
+++ b/code/data/fields/_module.mjs
@@ -1,4 +1,5 @@
 export { default as AbilityScoreField } from "./ability-score-field.mjs";
+export { default as ContainerField } from "./container-field.mjs";
 export { default as EquipmentField } from "./equipment-field.mjs";
 export { default as FormulaField } from "./formula-field.mjs";
 export { default as IdentifierField } from "./identifier-field.mjs";

--- a/code/data/fields/_module.mjs
+++ b/code/data/fields/_module.mjs
@@ -1,9 +1,9 @@
 export { default as AbilityScoreField } from "./ability-score-field.mjs";
-export { default as ContainerField } from "./container-field.mjs";
 export { default as EquipmentField } from "./equipment-field.mjs";
 export { default as FormulaField } from "./formula-field.mjs";
 export { default as IdentifierField } from "./identifier-field.mjs";
 export { default as LocalDocumentField } from "./local-document-field.mjs";
 export { default as MembersField } from "./members-field.mjs";
 export { default as SourceField } from "./source-field.mjs";
+export { default as StorageField } from "./storage-field.mjs";
 export { default as TypedRecordField } from "./typed-record-field.mjs";

--- a/code/data/fields/container-field.mjs
+++ b/code/data/fields/container-field.mjs
@@ -1,0 +1,32 @@
+/**
+ * @import RyuutamaItem from "../../documents/item.mjs";
+ */
+
+/**
+ * Extension of foreign document field to store parent container id.
+ */
+export default class ContainerField extends foundry.data.fields.ForeignDocumentField {
+  constructor() {
+    super(foundry.documents.BaseItem, { idOnly: true });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve a parent container of an item.
+   * @param {RyuutamaItem} item
+   * @returns {RyuutamaItem|null|Promise<RyuutamaItem|null>}
+   */
+  static getContainer(item) {
+    if (!item.system.schema.has("container")) return null;
+
+    let container;
+
+    // Embedded documents imply that the parent document is also loaded, so can be accessed synchronously.
+    if (item.isEmbedded || !item.inCompendium) container = item.collection.get(item.system.container);
+    else container = item.collection.getDocument(item.system.container);
+
+    const verify = item => item && (item.type === "container") ? item : null;
+    return (container instanceof Promise) ? container.then(verify) : verify(container);
+  }
+}

--- a/code/data/fields/container-field.mjs
+++ b/code/data/fields/container-field.mjs
@@ -26,7 +26,7 @@ export default class ContainerField extends foundry.data.fields.ForeignDocumentF
     if (item.isEmbedded || !item.inCompendium) container = item.collection.get(item.system.container);
     else container = item.collection.getDocument(item.system.container);
 
-    const verify = item => item && (item.type === "container") ? item : null;
+    const verify = item => item && item.system.isContainer ? item : null;
     return (container instanceof Promise) ? container.then(verify) : verify(container);
   }
 }

--- a/code/data/fields/storage-field.mjs
+++ b/code/data/fields/storage-field.mjs
@@ -5,7 +5,7 @@
 /**
  * Extension of foreign document field to store parent container id.
  */
-export default class ContainerField extends foundry.data.fields.ForeignDocumentField {
+export default class StorageField extends foundry.data.fields.ForeignDocumentField {
   constructor() {
     super(foundry.documents.BaseItem, { idOnly: true });
   }
@@ -17,16 +17,16 @@ export default class ContainerField extends foundry.data.fields.ForeignDocumentF
    * @param {RyuutamaItem} item
    * @returns {RyuutamaItem|null|Promise<RyuutamaItem|null>}
    */
-  static getContainer(item) {
-    if (!item.system.schema.has("container")) return null;
+  static getParentStorage(item) {
+    if (!item.system.schema.has("storage")) return null;
 
     let container;
 
     // Embedded documents imply that the parent document is also loaded, so can be accessed synchronously.
-    if (item.isEmbedded || !item.inCompendium) container = item.collection.get(item.system.container);
-    else container = item.collection.getDocument(item.system.container);
+    if (item.isEmbedded || !item.inCompendium) container = item.collection.get(item.system.storage);
+    else container = item.collection.getDocument(item.system.storage);
 
-    const verify = item => item && item.system.isContainer ? item : null;
+    const verify = item => item && item.system.isStorage ? item : null;
     return (container instanceof Promise) ? container.then(verify) : verify(container);
   }
 }

--- a/code/data/item/_types.d.ts
+++ b/code/data/item/_types.d.ts
@@ -21,7 +21,11 @@ declare module "./animal.mjs" {
     }
     modifiers: Set<string>;
     price: {
-      value: number | null;
+      bonus: number;
+      multiplier: number;
+      saleable: boolean;
+      sell: number;
+      value: number;
     }
   }
 }
@@ -54,24 +58,29 @@ declare module "./class.mjs" {
 
 /* -------------------------------------------------- */
 
+interface RationData {
+  type: string;
+  modifier?: string;
+  id: string;
+  label: string;
+}
+
 declare module "./container.mjs" {
   export default interface ContainerData {
     capacity: {
       max: number | null;
+      rations: number;
       water: number | null;
-      value: number;
       total: number | null;
-      pct: number;
     }
     price: {
       value: number;
     }
     properties: Set<"waterContainer">;
-    rations: Record<string, { type: string, modifier?: string }>;
+    rations: Record<string, RationData> & { animalFeed: RationData[], food: RationData[], ration: RationData[], water: RationData[] };
     size: {
       value: 1 | 3 | 5;
     }
-    weight: number;
   }
 }
 
@@ -92,7 +101,7 @@ declare module "./herb.mjs" {
       effect: string;
     }
     price: {
-      value: number | null;
+      value: number;
     }
     terrain: {
       details: string;

--- a/code/data/item/_types.d.ts
+++ b/code/data/item/_types.d.ts
@@ -3,6 +3,7 @@ export {};
 import "./templates/_types";
 import ActionsModel from "../actions-model.mjs";
 import BaseData from "./templates/base.mjs";
+import StorageData from "./templates/storage.mjs";
 
 declare module "./accessory.mjs" {
   export default interface AccessoryData {}
@@ -12,20 +13,22 @@ declare module "./accessory.mjs" {
 
 declare module "./animal.mjs" {
   export default interface AnimalData {
-    capacity: {
-      max: number | null;
+    capacity: StorageData["capacity"] & {
+      canCarry: boolean;
+      canRide: boolean;
       riders: number | null;
+      total: number | null;
+      label: string;
     }
     category: {
       value: string;
     }
     modifiers: Set<string>;
-    price: {
+    price: StorageData["price"] & {
       bonus: number;
       multiplier: number;
       saleable: boolean;
       sell: number;
-      value: number;
     }
   }
 }
@@ -67,14 +70,10 @@ interface RationData {
 
 declare module "./container.mjs" {
   export default interface ContainerData {
-    capacity: {
-      max: number | null;
+    capacity: StorageData["capacity"] & {
       rations: number;
       water: number | null;
       total: number | null;
-    }
-    price: {
-      value: number;
     }
     properties: Set<"waterContainer">;
     rations: Record<string, RationData> & { animalFeed: RationData[], food: RationData[], ration: RationData[], water: RationData[] };

--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -1,8 +1,8 @@
-import BaseData from "./templates/base.mjs";
+import StorageData from "./templates/storage.mjs";
 
 const { NumberField, SetField, SchemaField, StringField } = foundry.data.fields;
 
-export default class AnimalData extends BaseData {
+export default class AnimalData extends StorageData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
@@ -17,11 +17,7 @@ export default class AnimalData extends BaseData {
 
   /** @inheritdoc */
   static defineSchema() {
-    return Object.assign(super.defineSchema(), {
-      capacity: new SchemaField({
-        max: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
-        riders: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
-      }),
+    const schema = Object.assign(super.defineSchema(), {
       category: new SchemaField({
         value: new StringField({
           required: true,
@@ -30,10 +26,13 @@ export default class AnimalData extends BaseData {
         }),
       }),
       modifiers: new SetField(new StringField()),
-      price: new SchemaField({
-        value: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
-      }),
     });
+
+    schema.capacity.extendFields({
+      riders: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
+    });
+
+    return schema;
   }
 
   /* -------------------------------------------------- */
@@ -122,6 +121,10 @@ export default class AnimalData extends BaseData {
 
   /** @inheritdoc */
   async _prepareSubtypeContext(sheet, context, options) {
+    const contents = await this.contents;
+    const capacity = await this.calculateCapacity();
+    const pct = Math.clamp(Math.round(capacity / this.capacity.max * 100), 0, 100);
+
     // Prepare modifiers.
     const config = ryuutama.config.animalModifiers;
     const isEditable = sheet.isEditable && sheet.isEditMode;
@@ -135,14 +138,21 @@ export default class AnimalData extends BaseData {
     // 'Well-Traveled' applies only to Riding Animals.
     if (![ryuutama.CONST.ANIMAL_TYPES.RIDING, ryuutama.CONST.ANIMAL_TYPES.RIDING_LARGE].includes(this.category.value))
       delete choices.wellTraveled;
+
     for (const k of this._source.modifiers) {
       if (!(k in choices)) choices[k] = { value: k, label: k };
     }
     context.modifiers = Object.values(choices);
 
     // Animal capacity details.
-    const { ride, capacity } = ryuutama.config.animalTypes[this.category.value];
-    context.animal = { defaultRiding: ride, defaultCapacity: capacity };
+    const animalConfig = ryuutama.config.animalTypes[this.category.value];
+    context.animal = {
+      canCarry: this.capacity.canCarry,
+      defaultRiding: animalConfig.ride,
+      defaultCapacity: animalConfig.capacity,
+      capacity: { pct, value: capacity, max: this.capacity.max },
+      contents: contents.map(item => ({ document: item })),
+    };
   }
 
   /* -------------------------------------------------- */
@@ -159,5 +169,32 @@ export default class AnimalData extends BaseData {
       ].filter(_ => _),
     };
     if (section.tags.length) context.tagSections.push(section);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareDeleteDialogOptions(options = {}, operation = {}) {
+    const dialogOptions = await super._prepareDeleteDialogOptions(options, operation) ?? {};
+    const contents = await this.contents;
+    if (!contents.length) return dialogOptions;
+
+    return foundry.utils.mergeObject(dialogOptions, {
+      yes: {
+        callback: async (event, button, dialog) => {
+          const deleteContents = button.form.elements["deleteContents"].checked;
+          return this.parent.delete({ ...operation, deleteContents });
+        },
+      },
+      render: (event, dialog) => {
+        const { createFormGroup, createCheckboxInput } = foundry.applications.fields;
+        dialog.element.querySelector(".dialog-content").insertAdjacentElement("beforeend", createFormGroup({
+          label: _loc("RYUUTAMA.ITEM.ANIMAL.deleteDialogLabel"),
+          hint: _loc("RYUUTAMA.ITEM.ANIMAL.deleteDialogHint", { items: contents.length, name: this.parent.name }),
+          input: createCheckboxInput({ value: true, name: "deleteContents" }),
+          rootId: dialog.id,
+        }));
+      },
+    });
   }
 }

--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -53,9 +53,6 @@ export default class AnimalData extends StorageData {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-
-    this.capacity.total = this.capacity.max;
-
     this.#preparePrice();
     this.#prepareCategory();
     this.#prepareModifierLabels();
@@ -99,6 +96,7 @@ export default class AnimalData extends StorageData {
 
     this.capacity.riders = this.capacity.canRide ? (this.capacity.riders ?? config.ride) : null;
     this.capacity.max = this.capacity.canCarry ? (this.capacity.max ?? config.capacity) : null;
+    this.capacity.total = this.capacity.max;
 
     this.category.label = config.label;
   }
@@ -158,13 +156,17 @@ export default class AnimalData extends StorageData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
 
     context.typeTag = this.category.label;
+
+    const cValue = await this.calculateCapacity();
+    const formula = `${cValue} / ${this.capacity.total}`;
+
     const section = {
       tags: [
-        this.capacity.max ? { label: _loc("RYUUTAMA.TOOLTIP.capacity", { formula: this.capacity.max }) } : null,
+        this.capacity.canCarry ? { label: _loc("RYUUTAMA.TOOLTIP.capacity", { formula }) } : null,
         this.capacity.riders ? { label: _loc("RYUUTAMA.TOOLTIP.riders", { formula: this.capacity.riders }) } : null,
       ].filter(_ => _),
     };

--- a/code/data/item/animal.mjs
+++ b/code/data/item/animal.mjs
@@ -73,7 +73,7 @@ export default class AnimalData extends BaseData {
     const p = this.price;
     p.bonus = 0;
     p.multiplier = 1;
-    p.total = p.value ?? base;
+    p.value = p.value ?? base;
 
     for (const mod of this.modifiers) {
       const config = ryuutama.config.animalModifiers[mod];
@@ -83,7 +83,7 @@ export default class AnimalData extends BaseData {
       else p.multiplier *= cost;
     }
 
-    p.total = Math.floor(p.total * p.multiplier + p.bonus);
+    p.value = Math.floor(p.value * p.multiplier + p.bonus);
     p.sell = Math.floor(p.total / 2);
     p.saleable = p.sell > 0;
   }

--- a/code/data/item/armor.mjs
+++ b/code/data/item/armor.mjs
@@ -55,8 +55,8 @@ export default class ArmorData extends PhysicalData {
   }
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
 
     context.tagSections.push({
       tags: [

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -150,11 +150,13 @@ export default class ContainerData extends StorageData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
+
+    const cValue = await this.calculateCapacity();
 
     const isWaterContainer = this.properties.has("waterContainer");
-    const formula = `${this.capacity.value} / ${this.capacity.total}`;
+    const formula = `${cValue} / ${this.capacity.total}`;
     context.tagSections.push({
       tags: [
         { label: _loc(isWaterContainer ? "RYUUTAMA.TOOLTIP.waterCapacity" : "RYUUTAMA.TOOLTIP.capacity", { formula }) },

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -114,7 +114,7 @@ export default class ContainerData extends StorageData {
       });
     }
 
-    this.capacity.total = isWaterContainer ? this.capacity.water : this.capacity.max;
+    this.capacity.total = (isWaterContainer ? this.capacity.water : this.capacity.max) ?? 0;
   }
 
   /* -------------------------------------------------- */
@@ -123,9 +123,7 @@ export default class ContainerData extends StorageData {
   async _prepareSubtypeContext(sheet, context, options) {
     const contents = await this.contents;
     const capacity = await this.calculateCapacity();
-    const pct = this.capacity.total === null
-      ? null
-      : Math.clamp(Math.round(capacity / this.capacity.total * 100), 0, 100);
+    const pct = Math.clamp(Math.round(capacity / this.capacity.total * 100), 0, 100);
 
     const ctx = context.container = {
       capacity: { pct, value: capacity, max: this.capacity.total },
@@ -154,7 +152,6 @@ export default class ContainerData extends StorageData {
     await super._prepareTooltipContext(context, options);
 
     const cValue = await this.calculateCapacity();
-
     const isWaterContainer = this.properties.has("waterContainer");
     const formula = `${cValue} / ${this.capacity.total}`;
     context.tagSections.push({

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -1,4 +1,4 @@
-import BaseData from "./templates/base.mjs";
+import StorageData from "./templates/storage.mjs";
 
 /**
  * @import RyuutamaItem from "../../documents/item.mjs";
@@ -6,7 +6,7 @@ import BaseData from "./templates/base.mjs";
 
 const { NumberField, SchemaField, SetField, StringField, TypedObjectField, TypedSchemaField } = foundry.data.fields;
 
-export default class ContainerData extends BaseData {
+export default class ContainerData extends StorageData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
@@ -21,14 +21,7 @@ export default class ContainerData extends BaseData {
 
   /** @inheritdoc */
   static defineSchema() {
-    return Object.assign(super.defineSchema(), {
-      capacity: new SchemaField({
-        max: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
-        water: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
-      }),
-      price: new SchemaField({
-        value: new NumberField({ nullable: false, initial: 1, min: 0, integer: true }),
-      }),
+    const schema = Object.assign(super.defineSchema(), {
       properties: new SetField(new StringField({ choices: ryuutama.CONST.CONTAINER_PROPERTIES._toConfig })),
       rations: new TypedObjectField(
         new TypedSchemaField(rationTypes()),
@@ -38,6 +31,12 @@ export default class ContainerData extends BaseData {
         value: new NumberField({ nullable: false, initial: 1, choices: ryuutama.CONST.ITEM_SIZES._toConfig }),
       }),
     });
+
+    schema.capacity.extendFields({
+      water: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
+    });
+
+    return schema;
   }
 
   /* -------------------------------------------------- */
@@ -56,69 +55,10 @@ export default class ContainerData extends BaseData {
 
   /* -------------------------------------------------- */
 
-  /**
-   * Contained items.
-   * @type {RyuutamaItem[]|Promise<RyuutamaItem[]>}
-   */
-  get contents() {
-    const item = this.parent;
-
-    // This container is on an actor.
-    if (item.isEmbedded) {
-      return item.collection.filter(i => i.system.container === item.id);
-    }
-
-    // This is an unowned container in a pack.
-    if (item.inCompendium) {
-      return item.compendium.getDocuments({ system: { container: item.id } });
-    }
-
-    // This is an unowned container in the world.
-    return item.collection.filter(i => i.system.container === item.id);
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Calculate the capacity in use from contained items and rations.
-   * @returns {Promise<number>}
-   */
+  /** @inheritdoc */
   async calculateCapacity() {
-    const items = await this.contents;
-    return items.reduce((acc, item) => acc + item.system.weight, this.capacity.rations);
-  }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _onUpdate(changed, options, userId) {
-    // Keep contents folder synchronized with container.
-    if ((game.user.id === userId) && foundry.utils.hasProperty(changed, "folder")) {
-      const contents = await this.contents;
-      const updates = contents.map(item => ({ _id: item.id, folder: changed.folder }));
-      const { pack, parent } = this.parent;
-      await getDocumentClass("Item").updateDocuments(updates, { pack, parent, ...options });
-    }
-
-    super._onUpdate(changed, options, userId);
-  }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _onDelete(options, userId) {
-    super._onDelete(options, userId);
-    if (userId !== game.user.id) return;
-
-    // Delete all contents of the container.
-    if (options.deleteContents) {
-      const items = await this.contents;
-      if (items.length) {
-        const ids = items.map(item => item.id);
-        const { pack, parent } = this.parent;
-        await getDocumentClass("Item").deleteDocuments(ids, { pack, parent });
-      }
-    }
+    const total = await super.calculateCapacity();
+    return total + this.capacity.rations;
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -211,8 +211,13 @@ export default class ContainerData extends BaseData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareDeleteDialogOptions(options, operation) {
-    return foundry.utils.mergeObject(super._prepareDeleteDialogOptions(), {
+  async _prepareDeleteDialogOptions(options = {}, operation = {}) {
+    const dialogOptions = await super._prepareDeleteDialogOptions(options, operation) ?? {};
+    const contents = await this.contents;
+    const rations = Object.values(ryuutama.CONST.RATION_TYPES).reduce((acc, type) => acc + this.rations[type].length, 0);
+    if (!contents.length && !rations) return dialogOptions;
+
+    return foundry.utils.mergeObject(dialogOptions, {
       yes: {
         callback: async (event, button, dialog) => {
           const deleteContents = button.form.elements["deleteContents"].checked;
@@ -223,7 +228,7 @@ export default class ContainerData extends BaseData {
         const { createFormGroup, createCheckboxInput } = foundry.applications.fields;
         dialog.element.querySelector(".dialog-content").insertAdjacentElement("beforeend", createFormGroup({
           label: _loc("RYUUTAMA.ITEM.CONTAINER.deleteDialogLabel"),
-          hint: _loc("RYUUTAMA.ITEM.CONTAINER.deleteDialogHint"),
+          hint: _loc("RYUUTAMA.ITEM.CONTAINER.deleteDialogHint", { items: contents.length, rations }),
           input: createCheckboxInput({ value: true, name: "deleteContents" }),
           rootId: dialog.id,
         }));

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -79,6 +79,17 @@ export default class ContainerData extends BaseData {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Calculate the capacity in use from contained items and rations.
+   * @returns {Promise<number>}
+   */
+  async calculateCapacity() {
+    const items = await this.contents;
+    return items.reduce((acc, item) => acc + item.system.weight, this.capacity.rations);
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   async _onUpdate(changed, options, userId) {
     // Keep contents folder synchronized with container.
@@ -115,8 +126,7 @@ export default class ContainerData extends BaseData {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.size.total = this.size.value;
-    this.capacity.value = 0;
+    this.capacity.rations = 0;
 
     const isWaterContainer = this.properties.has("waterContainer");
 
@@ -147,7 +157,7 @@ export default class ContainerData extends BaseData {
         : r.type !== ryuutama.CONST.RATION_TYPES.WATER;
       if (display) {
         this.rations[r.type].push(r);
-        this.capacity.value++;
+        this.capacity.rations++;
       }
     }
 
@@ -165,20 +175,24 @@ export default class ContainerData extends BaseData {
     }
 
     this.capacity.total = isWaterContainer ? this.capacity.water : this.capacity.max;
-    this.capacity.pct = Math.clamp(Math.round(this.capacity.value / this.capacity.total * 100), 0, 100) || 0;
-
-    // The amount this adds to a Traveler's capacity.
-    this.weight = this.size.total + this.capacity.value;
   }
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async _prepareSubtypeContext(sheet, context, options) {
+    const contents = await this.contents;
+    const capacity = await this.calculateCapacity();
+    const pct = this.capacity.total === null
+      ? null
+      : Math.clamp(Math.round(capacity / this.capacity.total * 100), 0, 100);
+
     const ctx = context.container = {
+      capacity: { pct, value: capacity, max: this.capacity.total },
+      contents: contents.map(item => ({ document: item })),
       rations: {},
-      contents: (await this.contents).map(item => ({ document: item })),
     };
+
     Object.values(ryuutama.CONST.RATION_TYPES).forEach(type => {
       const entries = sheet.document.system.rations[type];
       ctx.rations[type] = {
@@ -188,7 +202,7 @@ export default class ContainerData extends BaseData {
           : (type !== ryuutama.CONST.RATION_TYPES.WATER),
         label: ryuutama.config.rationTypes[type].label,
         disableDown: !entries.length || !context.editable,
-        disableUp: !context.editable || ((this.capacity.pct === 100) && (this.capacity.total !== null)),
+        disableUp: !context.editable || (pct === 100),
       };
     });
   }

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -56,6 +56,62 @@ export default class ContainerData extends BaseData {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Contained items.
+   * @type {RyuutamaItem[]|Promise<RyuutamaItem[]>}
+   */
+  get contents() {
+    const item = this.parent;
+
+    // This container is on an actor.
+    if (item.isEmbedded) {
+      return item.collection.filter(i => i.system.container === item.id);
+    }
+
+    // This is an unowned container in a pack.
+    if (item.inCompendium) {
+      return item.compendium.getDocuments({ system: { container: item.id } });
+    }
+
+    // This is an unowned container in the world.
+    return item.collection.filter(i => i.system.container === item.id);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onUpdate(changed, options, userId) {
+    // Keep contents folder synchronized with container.
+    if ((game.user.id === userId) && foundry.utils.hasProperty(changed, "folder")) {
+      const contents = await this.contents;
+      const updates = contents.map(item => ({ _id: item.id, folder: changed.folder }));
+      const { pack, parent } = this.parent;
+      await getDocumentClass("Item").updateDocuments(updates, { pack, parent, ...options });
+    }
+
+    super._onUpdate(changed, options, userId);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if (userId !== game.user.id) return;
+
+    // Delete all contents of the container.
+    if (options.deleteContents) {
+      const items = await this.contents;
+      if (items.length) {
+        const ids = items.map(item => item.id);
+        const { pack, parent } = this.parent;
+        await getDocumentClass("Item").deleteDocuments(ids, { pack, parent });
+      }
+    }
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
@@ -121,6 +177,7 @@ export default class ContainerData extends BaseData {
   async _prepareSubtypeContext(sheet, context, options) {
     const ctx = context.container = {
       rations: {},
+      contents: (await this.contents).map(item => ({ document: item })),
     };
     Object.values(ryuutama.CONST.RATION_TYPES).forEach(type => {
       const entries = sheet.document.system.rations[type];
@@ -148,6 +205,29 @@ export default class ContainerData extends BaseData {
       tags: [
         { label: _loc(isWaterContainer ? "RYUUTAMA.TOOLTIP.waterCapacity" : "RYUUTAMA.TOOLTIP.capacity", { formula }) },
       ],
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _prepareDeleteDialogOptions(options, operation) {
+    return foundry.utils.mergeObject(super._prepareDeleteDialogOptions(), {
+      yes: {
+        callback: async (event, button, dialog) => {
+          const deleteContents = button.form.elements["deleteContents"].checked;
+          return this.parent.delete({ ...operation, deleteContents });
+        },
+      },
+      render: (event, dialog) => {
+        const { createFormGroup, createCheckboxInput } = foundry.applications.fields;
+        dialog.element.querySelector(".dialog-content").insertAdjacentElement("beforeend", createFormGroup({
+          label: _loc("RYUUTAMA.ITEM.CONTAINER.deleteDialogLabel"),
+          hint: _loc("RYUUTAMA.ITEM.CONTAINER.deleteDialogHint"),
+          input: createCheckboxInput({ value: true, name: "deleteContents" }),
+          rootId: dialog.id,
+        }));
+      },
     });
   }
 

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -139,8 +139,8 @@ export default class HerbData extends BaseData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
 
     context.tagSections.push({
       tags: [

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -21,10 +21,10 @@ export default class HerbData extends BaseData {
       category: new SchemaField({
         value: new StringField({ required: true, initial: "physical", choices: ryuutama.CONST.HERB_TYPES._toConfig }),
       }),
-      container: new ryuutama.data.fields.ContainerField(),
       price: new SchemaField({
         value: new NumberField({ nullable: true, initial: null, min: 0, integer: true }),
       }),
+      storage: new ryuutama.data.fields.StorageField(),
       terrain: new SchemaField({
         details: new StringField({ required: true }),
         level: new NumberField({ initial: 1, nullable: false, integer: true, min: 1, max: 5 }),

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -21,6 +21,7 @@ export default class HerbData extends BaseData {
       category: new SchemaField({
         value: new StringField({ required: true, initial: "physical", choices: ryuutama.CONST.HERB_TYPES._toConfig }),
       }),
+      container: new ryuutama.data.fields.ContainerField(),
       price: new SchemaField({
         value: new NumberField({ nullable: true, initial: null, min: 0, integer: true }),
       }),

--- a/code/data/item/herb.mjs
+++ b/code/data/item/herb.mjs
@@ -81,9 +81,9 @@ export default class HerbData extends BaseData {
 
     if (this.price.value === null) {
       switch (this.terrain.level) {
-        case 1: this.price.total = 100; break;
-        case 2: this.price.total = 300; break;
-        case 3: this.price.total = 800; break;
+        case 1: this.price.value = 100; break;
+        case 2: this.price.value = 300; break;
+        case 3: this.price.value = 800; break;
       }
     }
 

--- a/code/data/item/shield.mjs
+++ b/code/data/item/shield.mjs
@@ -59,8 +59,8 @@ export default class ShieldData extends PhysicalData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
 
     context.tagSections.push({
       tags: [

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -138,8 +138,8 @@ export default class SpellData extends BaseData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
 
     context.tagSections.push({
       tags: [

--- a/code/data/item/templates/_module.mjs
+++ b/code/data/item/templates/_module.mjs
@@ -1,3 +1,4 @@
 export { default as BaseData } from "./base.mjs";
 export { default as GearData } from "./gear.mjs";
 export { default as PhysicalData } from "./physical.mjs";
+export { default as StorageData } from "./storage.mjs";

--- a/code/data/item/templates/_types.d.ts
+++ b/code/data/item/templates/_types.d.ts
@@ -15,6 +15,18 @@ declare module "./base.mjs" {
 
 /* -------------------------------------------------- */
 
+declare module "./gear.mjs" {
+  export default interface GearData {
+    gear: {
+      check: number;
+      custom: string;
+    }
+  }
+}
+
+
+/* -------------------------------------------------- */
+
 declare module "./physical.mjs" {
   export default interface PhysicalData {
     container: RyuutamaItem | Promise<RyuutamaItem> | null;
@@ -40,11 +52,13 @@ declare module "./physical.mjs" {
 
 /* -------------------------------------------------- */
 
-declare module "./gear.mjs" {
-  export default interface GearData {
-    gear: {
-      check: number;
-      custom: string;
+declare module "./storage.mjs" {
+  export default interface StorageData {
+    capacity: {
+      max: number;
+    }
+    price: {
+      value: number;
     }
   }
 }

--- a/code/data/item/templates/_types.d.ts
+++ b/code/data/item/templates/_types.d.ts
@@ -17,6 +17,7 @@ declare module "./base.mjs" {
 
 declare module "./physical.mjs" {
   export default interface PhysicalData {
+    container: RyuutamaItem | Promise<RyuutamaItem> | null;
     durability: {
       spent: number;
     }
@@ -35,6 +36,7 @@ declare module "./physical.mjs" {
 declare module "./gear.mjs" {
   export default interface GearData {
     gear: {
+      check: number;
       custom: string;
     }
   }

--- a/code/data/item/templates/_types.d.ts
+++ b/code/data/item/templates/_types.d.ts
@@ -19,14 +19,21 @@ declare module "./physical.mjs" {
   export default interface PhysicalData {
     container: RyuutamaItem | Promise<RyuutamaItem> | null;
     durability: {
+      max: number;
+      multiplier: number;
       spent: number;
+      value: number;
     }
     modifiers: Set<string>;
     price: {
+      magical: number;
+      multiplier: number;
+      saleable: boolean;
+      sell: number;
       value: number;
     }
     size: {
-      value: number;
+      value: 1 | 3 | 5;
     }
   }
 }

--- a/code/data/item/templates/_types.d.ts
+++ b/code/data/item/templates/_types.d.ts
@@ -29,7 +29,6 @@ declare module "./gear.mjs" {
 
 declare module "./physical.mjs" {
   export default interface PhysicalData {
-    container: RyuutamaItem | Promise<RyuutamaItem> | null;
     durability: {
       max: number;
       multiplier: number;
@@ -47,6 +46,7 @@ declare module "./physical.mjs" {
     size: {
       value: 1 | 3 | 5;
     }
+    storage: string | null;
   }
 }
 

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -68,6 +68,16 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------------- */
 
   /**
+   * Is this a container able to hold other items?
+   * @type {boolean}
+   */
+  get isContainer() {
+    return false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * The amount this adds to the capacity of a parent actor.
    * @type {number}
    */

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -67,6 +67,27 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
 
   /* -------------------------------------------------- */
 
+  /**
+   * The amount this adds to the capacity of a parent actor.
+   * @type {number}
+   */
+  get weight() {
+    return this.size?.value ?? 0;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+
+    // Prepare size.
+    if (!this.size) return;
+    if (this.modifiers?.has("mythril")) this.size.value = Math.max(1, this.size.value - 2);
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   async _preCreate(data, options, user) {
     if ((await super._preCreate(data, options, user)) === false) return false;

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -71,7 +71,7 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
    * Is this a container able to hold other items?
    * @type {boolean}
    */
-  get isContainer() {
+  get isStorage() {
     return false;
   }
 

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -163,4 +163,14 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
    * @returns {Promise<void>}
    */
   async _prepareSubtypeContext(sheet, context, options) {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare dialog options for a deletion dialog for an item of this type.
+   * @returns {object}
+   */
+  _prepareDeleteDialogOptions() {
+    return {};
+  }
 }

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -1,4 +1,8 @@
 /**
+ * @import { DatabaseDeleteOperation } from "@common/abstract/_types.mjs";
+ */
+
+/**
  * @typedef ItemSubtypeMetadata
  * @property {boolean} [inventory]        Unless explicitly `false`, this item type appears in inventories.
  * @property {number} [sort]              The order in which this item type appears as a section on actor sheets.
@@ -168,9 +172,9 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
 
   /**
    * Prepare dialog options for a deletion dialog for an item of this type.
-   * @returns {object}
+   * @param {object} [options]                      Additional options passed to `DialogV2.confirm`
+   * @param {DatabaseDeleteOperation} [operation]   Document deletion options.
+   * @returns {Promise<object|void>}
    */
-  _prepareDeleteDialogOptions() {
-    return {};
-  }
+  async _prepareDeleteDialogOptions(options = {}, operation = {}) {}
 }

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -125,7 +125,7 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
       typeTag: _loc(`TYPES.Item.${this.parent.type}`),
     };
 
-    this._prepareTooltipContext(context);
+    await this._prepareTooltipContext(context);
 
     const htmlString = await foundry.applications.handlebars.renderTemplate(
       "systems/ryuutama/templates/ui/items/tooltip.hbs",
@@ -141,10 +141,11 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
 
   /**
    * Prepare subtype specific context for tooltips.
-   * @param {object} context
-   * @param {object} [options]
+   * @param {object} context      Rendering context. **will be mutated.**
+   * @param {object} [options]    Rendering options.
+   * @returns {Promise<void>}     A promise thast resolves once context has been mutated.
    */
-  _prepareTooltipContext(context, options = {}) {
+  async _prepareTooltipContext(context, options = {}) {
     if (this.modifierLabels?.length) {
       context.tagSections.push({
         tags: this.modifierLabels.map(label => ({ label })),

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -2,10 +2,14 @@ import BaseData from "./base.mjs";
 
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
+/**
+ * Extension of the base item data model for items with physical properties, such as weapons, containers, etc.
+ */
 export default class PhysicalData extends BaseData {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
+      container: new ryuutama.data.fields.ContainerField(),
       durability: new SchemaField({
         spent: new NumberField({ nullable: false, initial: 0, integer: true, min: 0 }),
       }),
@@ -26,6 +30,19 @@ export default class PhysicalData extends BaseData {
     ...super.LOCALIZATION_PREFIXES,
     "RYUUTAMA.PHYSICAL",
   ];
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Can this item be equipped? For unowned items, this returns `null`.
+   * @type {boolean|null}
+   */
+  get isEquippable() {
+    const item = this.parent;
+    if (!item.isEmbedded) return null;
+    return ryuutama.data.fields.EquipmentField.EQUIPMENT_ORDER.includes(item.type)
+      && !ryuutama.data.fields.ContainerField.getContainer(item);
+  }
 
   /* -------------------------------------------------- */
 

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -3,13 +3,13 @@ import BaseData from "./base.mjs";
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * Extension of the base item data model for items with physical properties, such as weapons, containers, etc.
+ * Extension of the base item data model for items with physical properties.
+ * These are all the items that can be equipped.
  */
 export default class PhysicalData extends BaseData {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      container: new ryuutama.data.fields.ContainerField(),
       durability: new SchemaField({
         spent: new NumberField({ nullable: false, initial: 0, integer: true, min: 0 }),
       }),
@@ -20,6 +20,7 @@ export default class PhysicalData extends BaseData {
       size: new SchemaField({
         value: new NumberField({ nullable: false, initial: 1, choices: ryuutama.CONST.ITEM_SIZES._toConfig }),
       }),
+      storage: new ryuutama.data.fields.StorageField(),
     });
   }
 
@@ -30,19 +31,6 @@ export default class PhysicalData extends BaseData {
     ...super.LOCALIZATION_PREFIXES,
     "RYUUTAMA.PHYSICAL",
   ];
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Can this item be equipped? For unowned items, this returns `null`.
-   * @type {boolean|null}
-   */
-  get isEquippable() {
-    const item = this.parent;
-    if (!item.isEmbedded) return null;
-    return ryuutama.data.fields.EquipmentField.EQUIPMENT_ORDER.includes(item.type)
-      && !ryuutama.data.fields.ContainerField.getContainer(item);
-  }
 
   /* -------------------------------------------------- */
 

--- a/code/data/item/templates/physical.mjs
+++ b/code/data/item/templates/physical.mjs
@@ -56,37 +56,15 @@ export default class PhysicalData extends BaseData {
 
   /* -------------------------------------------------- */
 
-  /**
-   * The amount this adds to the capacity.
-   * @type {number}
-   */
-  get weight() {
-    return this.size.total;
-  }
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    this.#prepareSize();
     this.#prepareDurability();
 
     // An item is broken if it has no durability remaining. This property is required for the price calculation.
     if (!this.durability.value) this.modifiers.add("broken");
     this.#preparePrice();
-
     this.#prepareModifierLabels();
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Prepare the size category.
-   */
-  #prepareSize() {
-    this.size.total = this.size.value;
-    if (this.modifiers.has("mythril")) this.size.total = Math.max(1, this.size.total - 2);
   }
 
   /* -------------------------------------------------- */
@@ -95,7 +73,7 @@ export default class PhysicalData extends BaseData {
    * Prepare durability data.
    */
   #prepareDurability() {
-    const max = this.modifiers.has("mythril") ? 5 : this.size.total;
+    const max = this.modifiers.has("mythril") ? 5 : this.size.value;
     let multiplier = 1;
 
     if (this.modifiers.has("sturdy")) multiplier = 2;
@@ -119,7 +97,6 @@ export default class PhysicalData extends BaseData {
     const p = this.price;
     p.magical = 0;
     p.multiplier = 1;
-    p.total = p.value;
 
     for (const mod of this.modifiers) {
       const config = ryuutama.config.itemModifiers[mod];
@@ -129,7 +106,7 @@ export default class PhysicalData extends BaseData {
       else p.multiplier *= cost;
     }
 
-    p.total = Math.floor(p.total * p.multiplier + p.magical);
+    p.value = Math.floor(p.value * p.multiplier + p.magical);
     p.sell = Math.floor(p.total / 2);
     p.saleable = (p.sell > 0) && !this.modifiers.has("broken");
   }

--- a/code/data/item/templates/storage.mjs
+++ b/code/data/item/templates/storage.mjs
@@ -11,6 +11,13 @@ const { NumberField, SchemaField } = foundry.data.fields;
  */
 export default class StorageData extends BaseData {
   /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    inventory: false,
+  }, { inplace: false }));
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
       capacity: new SchemaField({

--- a/code/data/item/templates/storage.mjs
+++ b/code/data/item/templates/storage.mjs
@@ -32,7 +32,7 @@ export default class StorageData extends BaseData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  get isContainer() {
+  get isStorage() {
     return true;
   }
 
@@ -48,16 +48,16 @@ export default class StorageData extends BaseData {
 
     // This container is on an actor.
     if (item.isEmbedded) {
-      return item.collection.filter(i => i.system.container === item.id);
+      return item.collection.filter(i => i.system.storage === item.id);
     }
 
     // This is an unowned container in a pack.
     if (item.inCompendium) {
-      return item.compendium.getDocuments({ system: { container: item.id } });
+      return item.compendium.getDocuments({ system: { storage: item.id } });
     }
 
     // This is an unowned container in the world.
-    return item.collection.filter(i => i.system.container === item.id);
+    return item.collection.filter(i => i.system.storage === item.id);
   }
 
   /* -------------------------------------------------- */

--- a/code/data/item/templates/storage.mjs
+++ b/code/data/item/templates/storage.mjs
@@ -1,0 +1,99 @@
+import BaseData from "./base.mjs";
+
+/**
+ * @import RyuutamaItem from "../../../documents/item.mjs";
+ */
+
+const { NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * Shared data for animals and containers, which can contain other items.
+ */
+export default class StorageData extends BaseData {
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      capacity: new SchemaField({
+        max: new NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
+      }),
+      price: new SchemaField({
+        value: new NumberField({ nullable: true, integer: true, initial: null, min: 0 }),
+      }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get isContainer() {
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Contained items.
+   * @type {RyuutamaItem[]|Promise<RyuutamaItem[]>}
+   */
+  get contents() {
+    /** @type {RyuutamaItem} */
+    const item = this.parent;
+
+    // This container is on an actor.
+    if (item.isEmbedded) {
+      return item.collection.filter(i => i.system.container === item.id);
+    }
+
+    // This is an unowned container in a pack.
+    if (item.inCompendium) {
+      return item.compendium.getDocuments({ system: { container: item.id } });
+    }
+
+    // This is an unowned container in the world.
+    return item.collection.filter(i => i.system.container === item.id);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Calculate the capacity in use from contained items and rations.
+   * @returns {Promise<number>}
+   */
+  async calculateCapacity() {
+    const items = await this.contents;
+    return items.reduce((acc, item) => acc + item.system.weight, 0);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onUpdate(changed, options, userId) {
+    // Keep contents folder synchronized with container.
+    if ((game.user.id === userId) && foundry.utils.hasProperty(changed, "folder")) {
+      const contents = await this.contents;
+      const updates = contents.map(item => ({ _id: item.id, folder: changed.folder }));
+      const { pack, parent } = this.parent;
+      await getDocumentClass("Item").updateDocuments(updates, { pack, parent, ...options });
+    }
+
+    super._onUpdate(changed, options, userId);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if (userId !== game.user.id) return;
+
+    // Delete all contents of the container.
+    if (options.deleteContents) {
+      const items = await this.contents;
+      if (items.length) {
+        const ids = items.map(item => item.id);
+        const { pack, parent } = this.parent;
+        await getDocumentClass("Item").deleteDocuments(ids, { pack, parent });
+      }
+    }
+  }
+}

--- a/code/data/item/weapon.mjs
+++ b/code/data/item/weapon.mjs
@@ -145,8 +145,8 @@ export default class WeaponData extends PhysicalData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _prepareTooltipContext(context, options = {}) {
-    super._prepareTooltipContext(context, options);
+  async _prepareTooltipContext(context, options = {}) {
+    await super._prepareTooltipContext(context, options);
     context.tagSections.push({
       tags: [
         { label: _loc("RYUUTAMA.TOOLTIP.accuracy", { formula: this.accuracy.label }) },

--- a/code/documents/collections/_module.mjs
+++ b/code/documents/collections/_module.mjs
@@ -1,1 +1,2 @@
 export { default as RyuutamaActors } from "./actors.mjs";
+export { default as RyuutamaItems } from "./items.mjs";

--- a/code/documents/collections/items.mjs
+++ b/code/documents/collections/items.mjs
@@ -3,9 +3,9 @@
  */
 export default class RyuutamaItems extends foundry.documents.collections.Items {
   /** @inheritdoc */
-  fromCompendium(document, { clearContainer = true, ...options } = {}) {
+  fromCompendium(document, { clearStorage = true, ...options } = {}) {
     const itemData = super.fromCompendium(document, options);
-    if (clearContainer) delete itemData.system?.container;
+    if (clearStorage) delete itemData.system?.storage;
     return itemData;
   }
 }

--- a/code/documents/collections/items.mjs
+++ b/code/documents/collections/items.mjs
@@ -1,0 +1,11 @@
+/**
+ * A subclass of the Items collection for Container functionality.
+ */
+export default class RyuutamaItems extends foundry.documents.collections.Items {
+  /** @inheritdoc */
+  fromCompendium(document, { clearContainer = true, ...options } = {}) {
+    const itemData = super.fromCompendium(document, options);
+    if (clearContainer) delete itemData.system?.container;
+    return itemData;
+  }
+}

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -44,6 +44,53 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Create items with respect to containers and their contents. This returns item data,
+   * which should be used with `Item.createDocuments` with `keepId: true`.
+   * @param {RyuutamaItem[]} items                The items to create.
+   * @param {object} [options]
+   * @param {RyuutamaItem} [options.container]    A container to place the items in.
+   * @returns {Promise<object[]>}                 Data for items to be created.
+   */
+  static async createWithContents(items, { container } = {}) {
+    let { containers = [], physical = [], other = [] } = Object.groupBy(items, item => {
+      if (item.type === "container") return "containers";
+      if (item.system.schema.has("container")) return "physical";
+      return "other";
+    });
+
+    physical = new Set(physical);
+
+    /**
+     * Containers and their new ids.
+     * @type {Map<string, string>}
+     */
+    const containerMap = new Map();
+
+    containers = await Promise.all(containers.map(async (item) => {
+      const id = foundry.utils.randomID();
+      containerMap.set(item.uuid, id);
+      const contents = await item.system.contents;
+      contents.forEach(c => physical.add(c));
+      item = game.items.fromCompendium(item);
+      foundry.utils.setProperty(item, "_id", id);
+      return item;
+    }));
+
+    physical = await Promise.all(Array.from(physical).map(async (item) => {
+      const parent = await ryuutama.data.fields.ContainerField.getContainer(item);
+      item = game.items.fromCompendium(item);
+      foundry.utils.setProperty(item, "system.container", containerMap.get(parent?.uuid) ?? container?.id ?? null);
+      return item;
+    }));
+
+    other = other.map(item => game.items.fromCompendium(item));
+
+    return [containers, physical, other].flat();
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   static getDefaultArtwork(itemData) {
     const model = CONFIG.Item.dataModels[itemData.type];
@@ -62,6 +109,63 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    if (options.render !== false) this.#renderContainers();
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preUpdate(changed, options, user) {
+    if ((await super._preUpdate(changed, options, user)) === false) return false;
+
+    if (foundry.utils.hasProperty(changed, "system.container")) {
+      options.formerContainer = (await ryuutama.data.fields.ContainerField.getContainer(this))?.uuid ?? null;
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    if (options.render !== false) this.#renderContainers(options.formerContainer);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if (options.render !== false) this.#renderContainers();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Render old and new containers.
+   * @param {string} [formerContainer]    Uuid of a former container to re-render.
+   */
+  async #renderContainers(formerContainer) {
+    // Re-render old container.
+    formerContainer = await fromUuid(formerContainer);
+    formerContainer?.sheet?.render();
+
+    // Re-render new container.
+    const newContainer = await ryuutama.data.fields.ContainerField.getContainer(this);
+    newContainer?.sheet?.render();
+
+    if (this.isEmbedded) return;
+
+    // Re-render the sidebar or containing compendium.
+    if (!this.inCompendium) ui.items.render();
+    else game.packs.get(this.pack).apps.forEach(a => a.render());
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   getRollData() {
     const item = (typeof this.system.getRollData === "function") ? this.system.getRollData() : { ...this.system };
     item.name = this.name;
@@ -69,5 +173,13 @@ export default class RyuutamaItem extends foundry.documents.Item {
     const rollData = this.actor?.getRollData() ?? {};
     rollData.item = item;
     return rollData;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async deleteDialog(options = {}, operation = {}) {
+    options = foundry.utils.mergeObject(this.system._prepareDeleteDialogOptions?.() ?? {}, options);
+    return super.deleteDialog(options, operation);
   }
 }

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -47,17 +47,19 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /**
    * Create items with respect to containers and their contents. This returns item data,
    * which should be used with `Item.createDocuments` with `keepId: true`.
-   * @param {RyuutamaItem[]} items                The items to create.
+   * @param {RyuutamaItem[]} items              The items to create.
    * @param {object} [options]
-   * @param {RyuutamaItem} [options.container]    A container to place the items in.
-   * @returns {Promise<object[]>}                 Data for items to be created.
+   * @param {RyuutamaItem} [options.storage]    A container to place the items in.
+   * @returns {Promise<object[]>}               Data for items to be created.
    */
-  static async createWithContents(items, { container } = {}) {
+  static async createWithContents(items, { storage } = {}) {
     let { containers = [], physical = [], other = [] } = Object.groupBy(items, item => {
-      if (item.system.isContainer) return "containers";
-      if (item.system.schema.has("container")) return "physical";
+      if (item.system.isStorage) return "containers";
+      if (item.system.schema.has("storage")) return "physical";
       return "other";
     });
+
+    // TODO: Container items in Animal items.
 
     physical = new Set(physical);
 
@@ -78,9 +80,9 @@ export default class RyuutamaItem extends foundry.documents.Item {
     }));
 
     physical = await Promise.all(Array.from(physical).map(async (item) => {
-      const parent = await ryuutama.data.fields.ContainerField.getContainer(item);
+      const parent = await ryuutama.data.fields.StorageField.getParentStorage(item);
       item = game.items.fromCompendium(item);
-      foundry.utils.setProperty(item, "system.container", containerMap.get(parent?.uuid) ?? container?.id ?? null);
+      foundry.utils.setProperty(item, "system.storage", containerMap.get(parent?.uuid) ?? storage?.id ?? null);
       return item;
     }));
 
@@ -111,7 +113,7 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /** @inheritdoc */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
-    if (options.render !== false) this.#renderContainers();
+    if (options.render !== false) this.#renderStorages();
   }
 
   /* -------------------------------------------------- */
@@ -120,8 +122,8 @@ export default class RyuutamaItem extends foundry.documents.Item {
   async _preUpdate(changed, options, user) {
     if ((await super._preUpdate(changed, options, user)) === false) return false;
 
-    if (foundry.utils.hasProperty(changed, "system.container")) {
-      options.formerContainer = (await ryuutama.data.fields.ContainerField.getContainer(this))?.uuid ?? null;
+    if (foundry.utils.hasProperty(changed, "system.storage")) {
+      options.formerStorage = (await ryuutama.data.fields.StorageField.getParentStorage(this))?.uuid ?? null;
     }
   }
 
@@ -130,7 +132,7 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /** @inheritdoc */
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
-    if (options.render !== false) this.#renderContainers(options.formerContainer);
+    if (options.render !== false) this.#renderStorages(options.formerStorage);
   }
 
   /* -------------------------------------------------- */
@@ -138,22 +140,22 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /** @inheritdoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
-    if (options.render !== false) this.#renderContainers();
+    if (options.render !== false) this.#renderStorages();
   }
 
   /* -------------------------------------------------- */
 
   /**
    * Render old and new containers.
-   * @param {string} [formerContainer]    Uuid of a former container to re-render.
+   * @param {string} [formerStorage]    Uuid of a former container to re-render.
    */
-  async #renderContainers(formerContainer) {
+  async #renderStorages(formerStorage) {
     // Re-render old container.
-    formerContainer = await fromUuid(formerContainer);
-    formerContainer?.sheet?.render();
+    formerStorage = await fromUuid(formerStorage);
+    formerStorage?.sheet?.render();
 
     // Re-render new container.
-    const newContainer = await ryuutama.data.fields.ContainerField.getContainer(this);
+    const newContainer = await ryuutama.data.fields.StorageField.getParentStorage(this);
     newContainer?.sheet?.render();
 
     if (this.isEmbedded) return;
@@ -179,7 +181,10 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
   /** @inheritdoc */
   async deleteDialog(options = {}, operation = {}) {
-    options = foundry.utils.mergeObject(await this.system._prepareDeleteDialogOptions?.(options, operation) ?? {}, options);
+    options = foundry.utils.mergeObject(
+      await this.system._prepareDeleteDialogOptions?.(options, operation) ?? {},
+      options,
+    );
     return super.deleteDialog(options, operation);
   }
 }

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -54,7 +54,7 @@ export default class RyuutamaItem extends foundry.documents.Item {
    */
   static async createWithContents(items, { container } = {}) {
     let { containers = [], physical = [], other = [] } = Object.groupBy(items, item => {
-      if (item.type === "container") return "containers";
+      if (item.system.isContainer) return "containers";
       if (item.system.schema.has("container")) return "physical";
       return "other";
     });

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -179,7 +179,7 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
   /** @inheritdoc */
   async deleteDialog(options = {}, operation = {}) {
-    options = foundry.utils.mergeObject(this.system._prepareDeleteDialogOptions?.() ?? {}, options);
+    options = foundry.utils.mergeObject(await this.system._prepareDeleteDialogOptions?.(options, operation) ?? {}, options);
     return super.deleteDialog(options, operation);
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -614,7 +614,7 @@
         "capacity": "Capacity",
         "contents": "Contents",
         "deleteDialogLabel": "Delete Contents",
-        "deleteDialogHint": "Deleting this container will also delete its contents."
+        "deleteDialogHint": "This container has contents inside it, and deleting it will also delete the {items} items and {rations} rations contained within."
       },
 
       "HERB": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -505,6 +505,12 @@
           "delete": "Delete Effect",
           "disable": "Disable Effect",
           "enable":"Enable Effect"
+        },
+        "ITEM": {
+          "delete": "Delete Item",
+          "edit": "Edit Item",
+          "view": "View Item",
+          "remove": "Remove Item"
         }
       },
       "CREATE_GROUP": {
@@ -605,7 +611,10 @@
         "PROPERTIES": {
           "waterContainer": "Water Container"
         },
-        "capacity": "Capacity"
+        "capacity": "Capacity",
+        "contents": "Contents",
+        "deleteDialogLabel": "Delete Contents",
+        "deleteDialogHint": "Deleting this container will also delete its contents."
       },
 
       "HERB": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -590,7 +590,10 @@
           "pet": "Pet Animal"
         },
 
-        "configuration": "Animal Configuration"
+        "configuration": "Animal Configuration",
+        "contents": "Contents",
+        "deleteDialogLabel": "Delete Contents",
+        "deleteDialogHint": "{name} is carrying contents, and deleting it will also delete the {items} items."
       },
 
       "CLASS": {

--- a/main.mjs
+++ b/main.mjs
@@ -83,6 +83,7 @@ Hooks.once("init", () => {
 
   CONFIG.CombatantGroup.documentClass = documents.RyuutamaCombatantGroup;
 
+  CONFIG.Item.collection = documents.collections.RyuutamaItems;
   CONFIG.Item.documentClass = documents.RyuutamaItem;
   CONFIG.Item.dataModels.accessory = data.item.AccessoryData;
   CONFIG.Item.dataModels.animal = data.item.AnimalData;
@@ -116,6 +117,7 @@ Hooks.once("init", () => {
   CONFIG.ui.combat = applications.sidebar.tabs.RyuutamaCombatTracker;
   CONFIG.ui.compendium = applications.sidebar.tabs.RyuutamaCompendiumDirectory;
   CONFIG.ui.habitat = applications.ui.CurrentHabitat;
+  CONFIG.ui.items = applications.sidebar.tabs.RyuutamaItemDirectory;
   CONFIG.ui.pause = applications.ui.RyuutamaGamePause;
 
   CONFIG.ux.TooltipManager = helpers.interaction.RyuutamaTooltipManager;
@@ -207,6 +209,11 @@ Hooks.once("i18nInit", () => {
 Hooks.once("setup", () => {
   Handlebars.registerHelper({
     "ryuutama-tooltip": helpers.interaction.RyuutamaTooltipManager.handlebarsHelper,
+  });
+
+  game.packs.forEach(pack => {
+    if (pack.metadata.type !== "Item") return;
+    pack.applicationClass = applications.sidebar.apps.RyuutamaItemCompendium;
   });
 });
 

--- a/styles/sheets/actors/traveler.css
+++ b/styles/sheets/actors/traveler.css
@@ -386,7 +386,7 @@
 
     .contents {
       display: grid;
-      grid-template-rows: 0fr 0fr 1fr;
+      grid-template-rows: 0fr 0fr 0fr 1fr;
       height: 100%;
       gap: .5rem;
       padding-top: .5rem;
@@ -418,6 +418,21 @@
           text-align: center;
           background-color: inherit;
           border-color: var(--c-primary);
+        }
+      }
+
+      .containers {
+        display: flex;
+        flex-wrap: wrap;
+
+        .container {
+          flex: 0 0 3rem;
+          margin: .25rem;
+          border: 1px solid var(--c-accent);
+
+          img {
+            border: none;
+          }
         }
       }
     }
@@ -626,7 +641,8 @@
   .defense-icon,
   .filters search .controls,
   .gold > label,
-  .experience {
+  .experience,
+  .containers .container {
     filter: drop-shadow(0 0 var(--shadow-spread, .1rem) var(--ryuutama-color-shadow-black));
   }
 

--- a/styles/sheets/actors/traveler.css
+++ b/styles/sheets/actors/traveler.css
@@ -433,6 +433,10 @@
           img {
             border: none;
           }
+
+          &.active {
+            transform: scale(1.15);
+          }
         }
       }
     }

--- a/styles/sheets/actors/traveler.css
+++ b/styles/sheets/actors/traveler.css
@@ -426,15 +426,13 @@
         flex-wrap: wrap;
 
         .container {
-          flex: 0 0 3rem;
+          flex: 0 0 2.75rem;
           margin: .25rem;
           border: 1px solid var(--c-accent);
+          transition: all 150ms ease-out;
 
-          img {
-            border: none;
-          }
-
-          &.active {
+          &.active,
+          &:hover {
             transform: scale(1.15);
           }
         }

--- a/templates/sheets/actors/traveler/inventory.hbs
+++ b/templates/sheets/actors/traveler/inventory.hbs
@@ -22,6 +22,15 @@
     {{!-- ITEM FILTERS --}}
     {{> "systems/ryuutama/templates/sheets/actors/traveler/search.hbs" search=inventory.search}}
 
+    {{!-- CONTAINERS --}}
+    <section class="containers">
+      {{#each inventory.containers}}
+      <a class="container" data-uuid="{{item.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}" data-action="changeInventoryView" data-item-context>
+        <img src="{{item.img}}" alt="{{item.name}}">
+      </a>
+      {{/each}}
+    </section>
+
     {{!-- INVENTORY --}}
     <section class="inventory" data-search-container="inventory">
       {{#each inventory.groups}}

--- a/templates/sheets/actors/traveler/inventory.hbs
+++ b/templates/sheets/actors/traveler/inventory.hbs
@@ -23,9 +23,9 @@
     {{> "systems/ryuutama/templates/sheets/actors/traveler/search.hbs" search=inventory.search}}
 
     {{!-- CONTAINERS --}}
-    <section class="containers">
+    <section class="containers document-list">
       {{#each inventory.containers}}
-      <a class="container" data-uuid="{{item.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}" data-action="changeInventoryView" data-item-context>
+      <a class="container {{ifThen active 'active' 'inactive'}}" data-uuid="{{item.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}" data-action="changeInventoryView" data-item-context data-drag-start>
         <img src="{{item.img}}" alt="{{item.name}}">
       </a>
       {{/each}}

--- a/templates/sheets/actors/traveler/inventory.hbs
+++ b/templates/sheets/actors/traveler/inventory.hbs
@@ -23,7 +23,7 @@
     {{> "systems/ryuutama/templates/sheets/actors/traveler/search.hbs" search=inventory.search}}
 
     {{!-- CONTAINERS --}}
-    <section class="containers document-list">
+    <section class="containers document-list" data-tooltip-direction="UP">
       {{#each inventory.containers}}
       <a class="container {{ifThen active 'active' 'inactive'}}" data-uuid="{{document.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=document.uuid}}" data-action="changeInventoryView" data-item-context data-drag-start>
         <img src="{{document.img}}" alt="{{document.name}}">

--- a/templates/sheets/actors/traveler/inventory.hbs
+++ b/templates/sheets/actors/traveler/inventory.hbs
@@ -25,8 +25,8 @@
     {{!-- CONTAINERS --}}
     <section class="containers document-list">
       {{#each inventory.containers}}
-      <a class="container {{ifThen active 'active' 'inactive'}}" data-uuid="{{item.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=item.uuid}}" data-action="changeInventoryView" data-item-context data-drag-start>
-        <img src="{{item.img}}" alt="{{item.name}}">
+      <a class="container {{ifThen active 'active' 'inactive'}}" data-uuid="{{document.uuid}}" data-tooltip-html="{{ryuutama-tooltip uuid=document.uuid}}" data-action="changeInventoryView" data-item-context data-drag-start>
+        <img src="{{document.img}}" alt="{{document.name}}">
       </a>
       {{/each}}
     </section>

--- a/templates/sheets/item-sheet/animal.hbs
+++ b/templates/sheets/item-sheet/animal.hbs
@@ -1,4 +1,8 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
+  {{#if animal.canCarry}}
+  <progress-bar id="{{rootId}}-capacity" data-pct="{{animal.capacity.pct}}" data-label="{{animal.capacity.value}} / {{animal.capacity.max}}"></progress-bar>
+  {{/if}}
+
   {{!-- PRICE --}}
   {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
 
@@ -17,4 +21,7 @@
   {{#if document.system.capacity.canCarry}}
   {{formGroup systemFields.capacity.fields.max value=(ifThen disabled document.system.capacity.max source.system.capacity.max) disabled=disabled classes="slim" placeholder=animal.defaultCapacity}}
   {{/if}}
+
+  {{!-- CONTENTS --}}
+  {{> document-list label=(localize "RYUUTAMA.ITEM.ANIMAL.contents") entries=animal.contents}}
 </section>

--- a/templates/sheets/item-sheet/animal.hbs
+++ b/templates/sheets/item-sheet/animal.hbs
@@ -1,6 +1,6 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
   {{!-- PRICE --}}
-  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
+  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
 
   {{!-- MODIFIERS --}}
   {{formGroup systemFields.modifiers value=(ifThen disabled document.system.modifiers source.system.modifiers) disabled=disabled options=modifiers type="checkboxes" classes="stacked"}}

--- a/templates/sheets/item-sheet/armor.hbs
+++ b/templates/sheets/item-sheet/armor.hbs
@@ -1,13 +1,13 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
   {{!-- PRICE --}}
-  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
+  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
 
   {{!-- SIZE & DURABILITY --}}
   <div class="form-group stacked">
     <label>{{localize "RYUUTAMA.ITEM.durability" value=document.system.durability.value max=document.system.durability.max}}</label>
     <div class="form-fields">
       {{formGroup systemFields.durability.fields.spent value=(ifThen disabled document.system.durability.spent source.system.durability.spent) disabled=disabled max=document.system.durability.max type="number"}}
-      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled}}
+      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.value source.system.size.value) disabled=disabled}}
     </div>
   </div>
 

--- a/templates/sheets/item-sheet/container.hbs
+++ b/templates/sheets/item-sheet/container.hbs
@@ -23,4 +23,7 @@
   </div>
   {{/if}}
   {{/each}}
+
+  {{!-- CONTENTS --}}
+  {{> document-list label=(localize "RYUUTAMA.ITEM.CONTAINER.contents") entries=container.contents}}
 </section>

--- a/templates/sheets/item-sheet/container.hbs
+++ b/templates/sheets/item-sheet/container.hbs
@@ -1,9 +1,11 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
+  <progress-bar id="{{rootId}}-capacity" data-pct="{{container.capacity.pct}}" data-label="{{container.capacity.value}} / {{container.capacity.max}}"></progress-bar>
+
   {{!-- PRICE --}}
   {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1" rootId=rootId}}
 
   {{!-- CONTAINER SIZE --}}
-  {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled classes="slim" rootId=rootId}}
+  {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.value source.system.size.value) disabled=disabled classes="slim" rootId=rootId}}
 
   {{!-- CAPACITY --}}
   {{formGroup systemFields.properties value=(ifThen disabled document.system.properties source.system.properties) disabled=disabled type="checkboxes" classes="stacked"}}

--- a/templates/sheets/item-sheet/gear.hbs
+++ b/templates/sheets/item-sheet/gear.hbs
@@ -1,12 +1,12 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
   {{!-- PRICE --}}
-  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
+  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
 
   <div class="form-group stacked">
     <label>{{localize "RYUUTAMA.ITEM.durability" value=document.system.durability.value max=document.system.durability.max}}</label>
     <div class="form-fields">
       {{formGroup systemFields.durability.fields.spent value=(ifThen disabled document.system.durability.spent source.system.durability.spent) disabled=disabled max=document.system.durability.max type="number"}}
-      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled}}
+      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.value source.system.size.value) disabled=disabled}}
     </div>
   </div>
 

--- a/templates/sheets/item-sheet/shield.hbs
+++ b/templates/sheets/item-sheet/shield.hbs
@@ -1,13 +1,13 @@
 <section data-tab="{{tabs.details.id}}" class="{{tabs.details.cssClass}}" data-group="{{tabs.details.group}}">
   {{!-- PRICE --}}
-  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.total source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
+  {{formGroup systemFields.price.fields.value value=(ifThen disabled document.system.price.value source.system.price.value) disabled=disabled classes="slim" placeholder="1"}}
 
   {{!-- SIZE & DURABILITY --}}
   <div class="form-group stacked">
     <label>{{localize "RYUUTAMA.ITEM.durability" value=document.system.durability.value max=document.system.durability.max}}</label>
     <div class="form-fields">
       {{formGroup systemFields.durability.fields.spent value=(ifThen disabled document.system.durability.spent source.system.durability.spent) disabled=disabled max=document.system.durability.max type="number"}}
-      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled}}
+      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.value source.system.size.value) disabled=disabled}}
     </div>
   </div>
 

--- a/templates/sheets/item-sheet/weapon.hbs
+++ b/templates/sheets/item-sheet/weapon.hbs
@@ -6,7 +6,7 @@
     <label>{{localize "RYUUTAMA.ITEM.durability" value=document.system.durability.value max=document.system.durability.max}}</label>
     <div class="form-fields">
       {{formGroup systemFields.durability.fields.spent value=(ifThen disabled document.system.durability.spent source.system.durability.spent) disabled=disabled max=document.system.durability.max type="number"}}
-      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.total source.system.size.value) disabled=disabled}}
+      {{formGroup systemFields.size.fields.value value=(ifThen disabled document.system.size.value source.system.size.value) disabled=disabled}}
     </div>
   </div>
 


### PR DESCRIPTION
Closes #4.

TODO:
- [x] Extend this logic to Animal items.
- [x] Change the rendering of the Traveler sheet, moving Container and Animal items out of the general item lists and into their own "menu".
- [x] Allow for swapping inventory view on the Traveler sheet, displaying contents of a Container/Animal item instead of the regular inventory.
- [x] Add capacity "progress bar" to container item sheets.
- [x] Add capacity "progress bar" to animal item sheets.
- [x] Adjust 'current capacity' of Container items, taking stored items (size 1 / 3 / 5) into account.
- [x] Adjust capacity added by containers / animals to the Traveler; each container is distinct and don't add their capacity to the traveler (but do add their size), nor should they add their contained items' weight to the traveler, only the container's own weight should be added.
- [x] Only show warning about deleted contents if the container actually has contents (items or rations).