### PR TITLE
[#348] Refactor i18n and `PhysicalData` to `EquippableData`

### DIFF
--- a/code/applications/api/document-sheet.mjs
+++ b/code/applications/api/document-sheet.mjs
@@ -29,7 +29,7 @@ export default class RyuutamaDocumentSheet extends HandlebarsApplicationMixin(Do
       controls: [{
         action: "openSourceConfig",
         icon: "fa-solid fa-book-bookmark",
-        label: "RYUUTAMA.SHEET.openSourceConfig",
+        label: "RYUUTAMA.SHEETS.openSourceConfig",
         ownership: "OWNER",
         visible: function() { return this.isEditable; },
       }],
@@ -119,7 +119,7 @@ export default class RyuutamaDocumentSheet extends HandlebarsApplicationMixin(Do
     const button = document.createElement("BUTTON");
     button.type = "button";
     button.classList.add("header-control", "icon", "fa-solid", "fa-fw", "fa-lock");
-    Object.assign(button.dataset, { action: "toggleEditMode", tooltip: "RYUUTAMA.SHEET.toggleEditMode" });
+    Object.assign(button.dataset, { action: "toggleEditMode", tooltip: "RYUUTAMA.SHEETS.toggleEditMode" });
     this.window.controls.insertAdjacentElement("afterend", button);
     return frame;
   }

--- a/code/applications/sidebar/tabs/combats.mjs
+++ b/code/applications/sidebar/tabs/combats.mjs
@@ -26,7 +26,7 @@ export default class RyuutamaCombatTracker extends foundry.applications.sidebar.
     const index = options.findIndex(o => o.label === "COMBATANT.ACTIONS.Reroll");
 
     const option = {
-      label: "RYUUTAMA.COMBAT.rollDelayed",
+      label: "RYUUTAMA.SIDEBAR.COMBATS.contextMenuRollDelayed",
       icon: "fa-solid fa-dice-d20",
       visible: target => this.viewed.combatants.get(target.dataset.combatantId).isOwner,
       onClick: (event, target) => {

--- a/code/config.mjs
+++ b/code/config.mjs
@@ -231,25 +231,25 @@ Prelocalization.prelocalize(containerProperties);
  */
 export const damageRollProperties = {
   damageMental: {
-    label: "RYUUTAMA.DAMAGE.PROPERTIES.damageMental",
+    label: "RYUUTAMA.ROLL.DAMAGE.PROPERTIES.damageMental",
     icon: "systems/ryuutama/assets/icons/properties/bolt-eye.svg",
   },
   ignoreArmor: {
-    label: "RYUUTAMA.DAMAGE.PROPERTIES.ignoreArmor",
+    label: "RYUUTAMA.ROLL.DAMAGE.PROPERTIES.ignoreArmor",
     icon: "systems/ryuutama/assets/icons/properties/shield-disabled.svg",
   },
   magical: {
-    label: "RYUUTAMA.DAMAGE.PROPERTIES.magical",
+    label: "RYUUTAMA.ROLL.DAMAGE.PROPERTIES.magical",
     icon: "systems/ryuutama/assets/icons/properties/eclipse-flare.svg",
     hidden: true,
   },
   mythril: {
-    label: "RYUUTAMA.DAMAGE.PROPERTIES.mythril",
+    label: "RYUUTAMA.ROLL.DAMAGE.PROPERTIES.mythril",
     icon: "systems/ryuutama/assets/icons/properties/fish-scales.svg",
     hidden: true,
   },
   orichalcum: {
-    label: "RYUUTAMA.DAMAGE.PROPERTIES.orichalcum",
+    label: "RYUUTAMA.ROLL.DAMAGE.PROPERTIES.orichalcum",
     icon: "systems/ryuutama/assets/icons/properties/layered-armor.svg",
     hidden: true,
   },

--- a/code/data/item/armor.mjs
+++ b/code/data/item/armor.mjs
@@ -1,8 +1,8 @@
-import PhysicalData from "./templates/physical.mjs";
+import EquippableData from "./templates/equippable.mjs";
 
 const { NumberField, SchemaField } = foundry.data.fields;
 
-export default class ArmorData extends PhysicalData {
+export default class ArmorData extends EquippableData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
@@ -33,7 +33,7 @@ export default class ArmorData extends PhysicalData {
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
-    "RYUUTAMA.ARMOR",
+    "RYUUTAMA.ITEM.ARMOR",
   ];
 
   /* -------------------------------------------------- */

--- a/code/data/item/class.mjs
+++ b/code/data/item/class.mjs
@@ -10,10 +10,7 @@ export default class ClassData extends BaseData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
-    {
-      inventory: false,
-      defaultArtwork: "systems/ryuutama/assets/icons/items/class.svg",
-    },
+    { defaultArtwork: "systems/ryuutama/assets/icons/items/class.svg" },
     { inplace: false },
   ));
 

--- a/code/data/item/container.mjs
+++ b/code/data/item/container.mjs
@@ -49,7 +49,6 @@ export default class ContainerData extends StorageData {
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
-    "RYUUTAMA.PHYSICAL",
     "RYUUTAMA.ITEM.CONTAINER",
   ];
 

--- a/code/data/item/shield.mjs
+++ b/code/data/item/shield.mjs
@@ -1,8 +1,8 @@
-import PhysicalData from "./templates/physical.mjs";
+import EquippableData from "./templates/equippable.mjs";
 
 const { NumberField, SchemaField } = foundry.data.fields;
 
-export default class ShieldData extends PhysicalData {
+export default class ShieldData extends EquippableData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
@@ -34,7 +34,7 @@ export default class ShieldData extends PhysicalData {
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
-    "RYUUTAMA.SHIELD",
+    "RYUUTAMA.ITEM.SHIELD",
   ];
 
   /* -------------------------------------------------- */

--- a/code/data/item/skill.mjs
+++ b/code/data/item/skill.mjs
@@ -8,10 +8,7 @@ export default class SkillData extends BaseData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
-    {
-      inventory: false,
-      defaultArtwork: "systems/ryuutama/assets/icons/items/skill.svg",
-    },
+    { defaultArtwork: "systems/ryuutama/assets/icons/items/skill.svg" },
     { inplace: false },
   ));
 

--- a/code/data/item/spell.mjs
+++ b/code/data/item/spell.mjs
@@ -7,10 +7,7 @@ export default class SpellData extends BaseData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
-    {
-      inventory: false,
-      defaultArtwork: "systems/ryuutama/assets/icons/items/spell.svg",
-    },
+    { defaultArtwork: "systems/ryuutama/assets/icons/items/spell.svg" },
     { inplace: false },
   ));
 

--- a/code/data/item/templates/_module.mjs
+++ b/code/data/item/templates/_module.mjs
@@ -1,4 +1,4 @@
 export { default as BaseData } from "./base.mjs";
+export { default as EquippableData } from "./equippable.mjs";
 export { default as GearData } from "./gear.mjs";
-export { default as PhysicalData } from "./physical.mjs";
 export { default as StorageData } from "./storage.mjs";

--- a/code/data/item/templates/_types.d.ts
+++ b/code/data/item/templates/_types.d.ts
@@ -15,20 +15,8 @@ declare module "./base.mjs" {
 
 /* -------------------------------------------------- */
 
-declare module "./gear.mjs" {
-  export default interface GearData {
-    gear: {
-      check: number;
-      custom: string;
-    }
-  }
-}
-
-
-/* -------------------------------------------------- */
-
-declare module "./physical.mjs" {
-  export default interface PhysicalData {
+declare module "./equippable.mjs" {
+  export default interface EquippableData {
     durability: {
       max: number;
       multiplier: number;
@@ -47,6 +35,17 @@ declare module "./physical.mjs" {
       value: 1 | 3 | 5;
     }
     storage: string | null;
+  }
+}
+
+/* -------------------------------------------------- */
+
+declare module "./gear.mjs" {
+  export default interface GearData {
+    gear: {
+      check: number;
+      custom: string;
+    }
   }
 }
 

--- a/code/data/item/templates/base.mjs
+++ b/code/data/item/templates/base.mjs
@@ -24,7 +24,7 @@ export default class BaseData extends foundry.abstract.TypeDataModel {
    * @type {ItemSubtypeMetadata}
    */
   static metadata = Object.freeze({
-    inventory: true,
+    inventory: false,
   });
 
   /* -------------------------------------------------- */

--- a/code/data/item/templates/equippable.mjs
+++ b/code/data/item/templates/equippable.mjs
@@ -6,7 +6,16 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
  * Extension of the base item data model for items with physical properties.
  * These are all the items that can be equipped.
  */
-export default class PhysicalData extends BaseData {
+export default class EquippableData extends BaseData {
+  /** @inheritdoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(
+    super.metadata,
+    { inventory: true },
+    { inplace: false },
+  ));
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
@@ -29,7 +38,7 @@ export default class PhysicalData extends BaseData {
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
-    "RYUUTAMA.PHYSICAL",
+    "RYUUTAMA.ITEM.EQUIPPABLE",
   ];
 
   /* -------------------------------------------------- */
@@ -140,9 +149,9 @@ export default class PhysicalData extends BaseData {
       if (v.hidden && !isEditable && !this.modifiers.has(k)) continue;
       choices[k] = { value: k, label: v.label };
     }
-    for (const k of this._source.modifiers) {
-      if (!(k in choices)) choices[k] = { value: k, label: k };
-    }
+    this._source.modifiers.forEach(k => {
+      choices[k] ??= { value: k, label: k };
+    });
     context.modifiers = Object.values(choices);
   }
 

--- a/code/data/item/templates/gear.mjs
+++ b/code/data/item/templates/gear.mjs
@@ -1,8 +1,11 @@
-import PhysicalData from "./physical.mjs";
+import EquippableData from "./equippable.mjs";
 
 const { SchemaField, StringField } = foundry.data.fields;
 
-export default class GearData extends PhysicalData {
+/**
+ * A shared subclass used for travel gear; accessories, capes, hats, shoes, staffs.
+ */
+export default class GearData extends EquippableData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,
@@ -29,20 +32,13 @@ export default class GearData extends PhysicalData {
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
-    "RYUUTAMA.GEAR",
+    "RYUUTAMA.ITEM.GEAR",
   ];
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static DETAILS_TEMPLATE = "systems/ryuutama/templates/sheets/item-sheet/gear.hbs";
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _prepareSubtypeContext(context, options) {
-    await super._prepareSubtypeContext(context, options);
-  }
 
   /* -------------------------------------------------- */
 

--- a/code/data/item/templates/storage.mjs
+++ b/code/data/item/templates/storage.mjs
@@ -11,13 +11,6 @@ const { NumberField, SchemaField } = foundry.data.fields;
  */
 export default class StorageData extends BaseData {
   /** @inheritdoc */
-  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    inventory: false,
-  }, { inplace: false }));
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
       capacity: new SchemaField({

--- a/code/data/item/weapon.mjs
+++ b/code/data/item/weapon.mjs
@@ -1,8 +1,8 @@
-import PhysicalData from "./templates/physical.mjs";
+import EquippableData from "./templates/equippable.mjs";
 
 const { ArrayField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
-export default class WeaponData extends PhysicalData {
+export default class WeaponData extends EquippableData {
   /** @inheritdoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(
     super.metadata,

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -23,7 +23,7 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
 
         const result = await foundry.applications.api.Dialog.input({
           window: {
-            title: `${_loc("RYUUTAMA.EFFECT.STATUS.HUD_APPLY.title")}: ${effectData.name}`,
+            title: `${_loc("RYUUTAMA.EFFECT.STATUS.configureStrength")}: ${effectData.name}`,
           },
           position: {
             width: 420,

--- a/lang/en.json
+++ b/lang/en.json
@@ -7,12 +7,14 @@
         "traveler": "A player character that embarks on a journey through unknown lands."
       }
     },
+
     "ActiveEffect": {
       "standard": "Standard Effect",
       "standardPl": "Standard Effects",
       "status": "Status Effect",
       "statusPl": "Status Effects"
     },
+
     "Actor": {
       "monster": "Monster",
       "monsterPl": "Monsters",
@@ -23,6 +25,7 @@
       "traveler": "Traveler",
       "travelerPl": "Travelers"
     },
+
     "Item": {
       "accessory": "Accessory",
       "accessoryPl": "Accessories",
@@ -53,14 +56,17 @@
       "weapon": "Weapon",
       "weaponPl": "Weapons"
     },
+
     "JournalEntryPage": {
       "reference": "Reference",
       "referencePl": "References"
     }
   },
+
   "RYUUTAMA": {
     "ACTOR": {
       "FIELDS": {},
+
       "CREATURE": {
         "FIELDS": {
           "condition.immunities.label": "Status Immunities",
@@ -88,8 +94,10 @@
           "resources.stamina.spent.label": "Spent"
         }
       },
+
       "PARTY": {
         "FIELDS": {},
+
         "PLACE_MEMBERS": {
           "createCombatants": "Create Combatants",
           "createCombatantsHint": "Create combatants for an encounter for each spawned token.",
@@ -103,6 +111,7 @@
           "selectAreaHint": "Spawn the tokens randomly within a selected area instead of manual positioning of each party member.",
           "title": "Place Members: {name}"
         },
+
         "actorOwner": "Owner",
         "placeMembers": "Place Members",
         "rationsHintEmptyA": "The party currently has no accumulated rations. To add rations (food, water, and animal feed) to the party, configure any container on a party member.",
@@ -111,9 +120,11 @@
         "rationsHintMissingFood": "The party has no accumulated rations of food.",
         "rationsHintMissingWater": "The party has no accumulated rations of water."
       },
+
       "RYUUJIN": {
         "FIELDS": {}
       },
+
       "MONSTER": {
         "FIELDS": {
           "attack.accuracy.bonus.label": "Bonus",
@@ -127,6 +138,7 @@
           "environment.season.label": "Season",
           "initiative.value.label": "Initiative"
         },
+
         "ATTACK": {
           "abilities": "Abilities",
           "accuracy": "Accuracy",
@@ -136,6 +148,7 @@
           "groupFaces": "Faces",
           "title": "Configure Attack: {name}"
         },
+
         "CATEGORIES": {
           "demon": "Demon",
           "demonstone": "Demonstone",
@@ -145,6 +158,7 @@
           "phantomPlant": "Phantom Plant",
           "undead": "Undead"
         },
+
         "armor": "Armor",
         "baseArmor": "Base Armor",
         "category": "Category: {category}",
@@ -160,6 +174,7 @@
         "season": "Season: {season}",
         "specialAbility": "Special Ability"
       },
+
       "TRAVELER": {
         "FIELDS": {
           "background.appearance.label": "Appearance",
@@ -170,22 +185,26 @@
           "fumbles.value.label": "Fumble Points",
           "gold.value.label": "Gold"
         },
+
         "TAGS": {
           "dragonFavor": "Favor of the Seasonal Dragons: {season}",
           "masteredWeapon": "Mastered Weapon: {weapon}",
           "specialtyTerrain": "Terrain Specialty: {terrain}",
           "specialtyWeather": "Weather Specialty: {weather}"
         },
+
         "noteTabs": {
           "appearance": "Appearance",
           "hometown": "Hometown / Reason for Travel",
           "notes": "Notes"
         },
+
         "TYPES": {
           "attack": "Attack Type",
           "magic": "Magic Type",
           "technical": "Technical Type"
         },
+
         "abilities": "Abilities",
         "baseDefensePoints": "Base Defense Points",
         "capacity": "Capacity",
@@ -222,6 +241,7 @@
         "skills": "Skills",
         "spells": "Magic"
       },
+
       "CONTEXT": {
         "EFFECT": {
           "edit": "Edit Effect",
@@ -229,6 +249,7 @@
           "disable": "Disable Effect",
           "enable": "Enable Effect"
         },
+
         "ITEM": {
           "assignSpecialAbility": "Special Ability",
           "castSpell": "Cast Spell",
@@ -237,11 +258,9 @@
           "equip": "Equip Item",
           "unequip": "Unequip Item",
           "view": "View Item"
-        },
-        "MISC": {
-          "classTag": "Class: {name}"
         }
       },
+
       "activeEffects": "Active Effects",
       "condition": "Condition",
       "defenseMagical": "Mag {value}",
@@ -267,6 +286,11 @@
     },
 
     "ABILITIES": {
+      "CONFIG": {
+        "title": "Configure {ability}: {name}",
+        "base": "Base Value"
+      },
+
       "strength": "Strength",
       "strengthAbbr": "STR",
       "dexterity": "Dexterity",
@@ -274,62 +298,60 @@
       "intelligence": "Intelligence",
       "intelligenceAbbr": "INT",
       "spirit": "Spirit",
-      "spiritAbbr": "SPI",
-
-      "CONFIG": {
-        "title": "Configure {ability}: {name}",
-        "base": "Base Value"
-      }
+      "spiritAbbr": "SPI"
     },
 
     "ADVANCEMENT": {
       "FIELDS": {},
-      "title": "Level Up: {name} - {nth} Level",
 
       "CLASS": {
+        "FIELDS": {},
+
         "label": "Configure Class",
-        "selectClass": "Select Class",
-        "FIELDS": {}
+        "selectClass": "Select Class"
       },
 
       "DRAGON_FAVOR": {
-        "label": "Configure Favor of the Seasonal Dragons",
         "FIELDS": {
           "choice.chosen.label": "Season"
-        }
+        },
+
+        "label": "Configure Favor of the Seasonal Dragons"
       },
 
       "HABITAT": {
-        "label": "Configure Terrain / Weather Specialty",
         "FIELDS": {
           "choice.chosen.terrain.label": "Terrain Type",
           "choice.chosen.weather.label": "Weather Pattern",
           "choice.type.label": "Subtype",
           "choice.type.hint": "Choose 1 from the twenty-two types of terrain and weather patterns. You gain a +2 bonus to any rolls involving that terrain or weather."
         },
+
+        "label": "Configure Terrain / Weather Specialty",
         "optionTerrain": "Terrain",
         "optionWeather": "Weather"
       },
 
       "STAT_INCREASE": {
-        "label": "Configure Stat Increase",
         "FIELDS": {
           "choice.chosen.label": "Chosen Ability",
           "choice.chosen.hint": "Every even level, you can choose one ability from [STR], [DEX], [INT], and [SPI] to increase by 1 die size (to a maximum of d12)."
-        }
+        },
+
+        "label": "Configure Stat Increase"
       },
 
       "RESOURCE": {
-        "label": "Configure Resource Increase",
         "FIELDS": {
           "choice.chosen.stamina.label": "HP",
           "choice.chosen.mental.label": "MP"
         },
-        "hint": "Each level, you gain three points to divide between HP and MP."
+
+        "hint": "Each level, you gain three points to divide between HP and MP.",
+        "label": "Configure Resource Increase"
       },
 
       "STATS": {
-        "label": "Configure Starting Stats",
         "FIELDS": {
           "choice.type.label": "Ability Score Set",
           "choice.type.hint": "Choose your starting ability scores from one of the three sets, arranged the way you prefer between the four abilities.",
@@ -338,35 +360,42 @@
           "choice.chosen.intelligence.label": "Intelligence",
           "choice.chosen.spirit.label": "Spirit"
         },
+
         "average": "Average (6, 6, 6, 6)",
-        "standard": "Standard (4, 6, 6, 8)",
-        "specialized": "Specialized (4, 4, 8, 8)"
+        "label": "Configure Starting Stats",
+        "specialized": "Specialized (4, 4, 8, 8)",
+        "standard": "Standard (4, 6, 6, 8)"
       },
 
       "STATUS_IMMUNITY": {
-        "label": "Configure Status Immunity",
         "FIELDS": {
           "choice.chosen.label": "Chosen Status Effect",
           "choice.chosen.hint": "Choose one of the six status effects. You are immune to that effect from now on."
-        }
+        },
+
+        "label": "Configure Status Immunity"
       },
 
       "TYPE": {
-        "label": "Configure Type",
         "FIELDS": {
           "choice.chosen.label": "Chosen Type",
           "choice.chosen.hint": "Choose one of the three archetypes. If you choose one that you already have, the abilities are cumulative.",
           "choice.magic.label": "Seasonal Magic"
-        }
+        },
+
+        "label": "Configure Type"
       },
 
       "WEAPON": {
-        "label": "Configure Mastered Weapon",
         "FIELDS": {
           "choice.chosen.label": "Chosen Weapon",
           "choice.chosen.hint": "Choose a weapon category to master. Making an attack with a weapon category that you have not mastered incurs a 1 HP penalty with each attack."
-        }
-      }
+        },
+
+        "label": "Configure Mastered Weapon"
+      },
+
+      "title": "Level Up: {name} - {nth} Level"
     },
 
     "BROWSER": {
@@ -379,6 +408,7 @@
         "spellCategory": "Spell Category",
         "spellLevel": "Spell Level"
       },
+
       "noResults": "No results found. Adjust the filters on the left.",
       "openCompendiumBrowser": "Open Compendium Browser",
       "selected": "Selected: {value} / {max}",
@@ -389,11 +419,13 @@
       "title": "Configure Condition: {name}",
       "current": "Current Condition"
     },
+
     "DEFENSE": {
       "title": "Configure Defense: {name}",
       "modifiers": "Damage Modifers",
       "modifiersHint": "Modifiers are added to any damage this actor will receive."
     },
+
     "JOURNEY": {
       "TYPES": {
         "travel": "Travel Check",
@@ -401,12 +433,14 @@
         "camping": "Camping Check"
       }
     },
+
     "RESOURCE": {
       "title": "Configure {resource}: {name}",
       "bonuses": "Bonuses",
       "stamina": "HP",
       "mental": "MP"
     },
+
     "SEASONS": {
       "spring": "Spring",
       "summer": "Summer",
@@ -447,8 +481,7 @@
         },
 
         "objects": "Objects"
-      },
-      "rollDelayed": "Roll Delayed Initiative"
+      }
     },
 
     "COMBATANT": {
@@ -460,16 +493,6 @@
       }
     },
 
-    "DAMAGE": {
-      "PROPERTIES": {
-        "damageMental": "Damage MP",
-        "ignoreArmor": "Ignore Armor",
-        "magical": "Magical",
-        "mythril": "Mythril",
-        "orichalcum": "Orichalcum"
-      }
-    },
-
     "EFFECT": {
       "STATUS": {
         "FIELDS": {
@@ -478,20 +501,19 @@
           "strength.value.hint": "The strength of the status effect determines how likely a character is to succumb to it.",
           "strength.value.label": "Strength"
         },
-        "HUD_APPLY": {
-          "title": "Configure Strength"
-        },
+        "configureStrength": "Configure Strength",
         "noActors": "No controlled tokens' actors were valid for application of this status."
       }
     },
 
     "HABITAT": {
-      "noPrimaryParty": "No primary party has been assigned.",
-      "openParty": "Display Party",
-      "targetNumber": "Target Number: {number}",
       "CONTEXT": {
         "viewFullImage": "View Full Image"
-      }
+      },
+
+      "noPrimaryParty": "No primary party has been assigned.",
+      "openParty": "Display Party",
+      "targetNumber": "Target Number: {number}"
     },
 
     "ITEM": {
@@ -499,6 +521,18 @@
         "identifier.label": "Identifier",
         "identifier.hint": "A unique identifier for this item. Two items with the same identifier are, for all intents and purposes, considered to be the same item."
       },
+
+      "ACTIONS": {
+        "FIELDS": {
+          "damage.formula.label": "Formula",
+          "damage.properties.label": "Properties",
+          "healing.formula.label": "Formula",
+          "healing.properties.label": "Properties"
+        },
+        "damage": "Damage",
+        "healing": "Healing"
+      },
+
       "CONTEXT": {
         "EFFECT": {
           "edit": "Edit Effect",
@@ -513,10 +547,12 @@
           "remove": "Remove Item"
         }
       },
+
       "CREATE_GROUP": {
         "travelingGear": "Traveling Gear",
         "weaponsArmor": "Weapons & Armor"
       },
+
       "MODIFIERS": {
         "beautiful": "Beautiful",
         "broken": "Broken",
@@ -535,27 +571,20 @@
         "used": "Used",
         "walking": "Walking"
       },
+
       "SIZES": {
         "size1": "Size 1",
         "size3": "Size 3",
         "size5": "Size 5"
       },
+
       "TABS": {
         "actions": "Actions",
         "details": "Details",
         "effects": "Effects",
         "identity": "Identity"
       },
-      "ACTIONS": {
-        "FIELDS": {
-          "damage.formula.label": "Formula",
-          "damage.properties.label": "Properties",
-          "healing.formula.label": "Formula",
-          "healing.properties.label": "Properties"
-        },
-        "damage": "Damage",
-        "healing": "Healing"
-      },
+
       "activeEffects": "Active",
       "defenses": "Defenses",
       "description": "Description",
@@ -563,6 +592,22 @@
       "disabledEffects": "Inactive",
       "durability": "Durability ({value}/{max})",
       "identifierError": "Invalid identifier.",
+
+      "EQUIPPABLE": {
+        "FIELDS": {
+          "price.value.label": "Gold Value",
+          "size.value.label": "Size",
+          "durability.spent.label": "Spent"
+        }
+      },
+
+      "GEAR": {
+        "FIELDS": {
+          "gear.custom.label": "Requirements",
+          "gear.custom.hint": "When the check bonus from this item applies."
+        },
+        "checkBonuses": "Check Bonuses"
+      },
 
       "ANIMAL": {
         "FIELDS": {
@@ -596,6 +641,13 @@
         "deleteDialogHint": "{name} is carrying contents, and deleting it will also delete the {items} items."
       },
 
+      "ARMOR": {
+        "FIELDS": {
+          "armor.penalty.label": "Penalty",
+          "armor.defense.label": "Defense Points"
+        }
+      },
+
       "CLASS": {
         "FIELDS": {
           "skills.label": "Skills",
@@ -609,7 +661,9 @@
       "CONTAINER": {
         "FIELDS": {
           "capacity.max.label": "Item Capacity",
-          "capacity.water.label": "Water Capacity"
+          "capacity.water.label": "Water Capacity",
+          "price.value.label": "Gold Value",
+          "size.value.label": "Size"
         },
         "PROPERTIES": {
           "waterContainer": "Water Container"
@@ -645,6 +699,14 @@
         "anyTerrain": "Any Terrain",
 
         "configuration": "Herb Details"
+      },
+
+      "SHIELD": {
+        "FIELDS": {
+          "armor.penalty.label": "Penalty",
+          "armor.defense.label": "Defense Points",
+          "armor.dodge.label": "Shield Dodge Value"
+        }
       },
 
       "SKILL": {
@@ -733,34 +795,13 @@
         "weaponDamage": "Damage"
       }
     },
-    "GEAR": {
-      "FIELDS": {
-        "gear.custom.label": "Requirements",
-        "gear.custom.hint": "When the check bonus from this item applies."
-      },
-      "checkBonuses": "Check Bonuses"
-    },
-    "PHYSICAL": {
-      "FIELDS": {
-        "price.value.label": "Gold Value",
-        "size.value.label": "Size",
-        "durability.spent.label": "Spent"
-      }
-    },
-    "ACCESSORY": {},
-    "ARMOR": {
-      "FIELDS": {
-        "armor.penalty.label": "Penalty",
-        "armor.defense.label": "Defense Points"
-      }
-    },
-    "CAPE": {},
-    "SHIELD": {
-      "FIELDS": {
-        "armor.penalty.label": "Penalty",
-        "armor.defense.label": "Defense Points",
-        "armor.dodge.label": "Shield Dodge Value"
-      }
+
+    "PACKS": {
+      "ACTORS": "Actors",
+      "CLASSES": "Classes",
+      "ITEMS": "Items",
+      "SPELLS": "Spells",
+      "TABLES": "Tables"
     },
 
     "PAGE": {
@@ -769,14 +810,6 @@
           "tooltip.label": "Tooltip"
         }
       }
-    },
-
-    "PACKS": {
-      "ACTORS": "Actors",
-      "CLASSES": "Classes",
-      "ITEMS": "Items",
-      "SPELLS": "Spells",
-      "TABLES": "Tables"
     },
 
     "RATIONS": {
@@ -802,11 +835,22 @@
     },
 
     "ROLL": {
+      "DAMAGE": {
+        "PROPERTIES": {
+          "damageMental": "Damage MP",
+          "ignoreArmor": "Ignore Armor",
+          "magical": "Magical",
+          "mythril": "Mythril",
+          "orichalcum": "Orichalcum"
+        }
+      },
+
       "WARNING": {
         "fumblesUnavailable": "{name} does not have any Fumble Points available.",
         "mentalUnavailable": "{name} does not have any MP available.",
         "staminaUnavailable": "{name} does not have any HP available."
       },
+
       "TYPES": {
         "accuracy": "Accuracy Check",
         "check": "Check",
@@ -816,6 +860,7 @@
         "journey": "Journey Check",
         "magic": "Magic Check"
       },
+
       "abilities": "Abilities",
       "concentration": "Concentration",
       "conditionRemoveStatuses": "Remove Statuses",
@@ -840,26 +885,32 @@
       "weaponBroken": "{weapon} (Broken)"
     },
 
-    "SETTINGS": {},
-
-    "SHEET": {
+    "SHEETS": {
+      "ACTOR": {
+        "MonsterSheet": "Ryuutama Monster Sheet",
+        "PartySheet": "Ryuutama Party Sheet",
+        "TravelerSheet": "Ryuutama Traveler Sheet"
+      },
+      "COMBATANT": {
+        "CombatantSheet": "Ryuutama Combatant Sheet"
+      },
+      "ITEM": {
+        "ItemSheet": "Ryuutama Item Sheet"
+      },
+      "PAGE": {
+        "ReferencePageSheet": "Ryuutama Reference Page Sheet"
+      },
       "openSourceConfig": "Show Source Config",
       "toggleEditMode": "Toggle Edit Mode"
-    },
-
-    "SHEETS": {
-      "CombatantSheet": "Ryuutama Combatant Sheet",
-      "ItemSheet": "Ryuutama Item Sheet",
-      "MonsterSheet": "Ryuutama Monster Sheet",
-      "PartySheet": "Ryuutama Party Sheet",
-      "ReferencePageSheet": "Ryuutama Reference Page Sheet",
-      "TravelerSheet": "Ryuutama Traveler Sheet"
     },
 
     "SIDEBAR": {
       "ACTORS": {
         "contextMenuAssignPrimaryParty": "Assign Primary Party",
         "contextMenuRemovePrimaryParty": "Remove Primary Party"
+      },
+      "COMBATS": {
+        "contextMenuRollDelayed": "Roll Delayed Initiative"
       }
     },
 

--- a/main.mjs
+++ b/main.mjs
@@ -151,27 +151,27 @@ Hooks.once("init", () => {
   // Register sheets.
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Item, ryuutama.id, applications.sheets.items.RyuutamaItemSheet,
-    { label: "RYUUTAMA.SHEETS.ItemSheet", makeDefault: true },
+    { label: "RYUUTAMA.SHEETS.ITEM.ItemSheet", makeDefault: true },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaTravelerSheet,
-    { label: "RYUUTAMA.SHEETS.TravelerSheet", makeDefault: true, types: ["traveler"] },
+    { label: "RYUUTAMA.SHEETS.ACTOR.TravelerSheet", makeDefault: true, types: ["traveler"] },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaPartySheet,
-    { label: "RYUUTAMA.SHEETS.PartySheet", makeDefault: true, types: ["party"] },
+    { label: "RYUUTAMA.SHEETS.ACTOR.PartySheet", makeDefault: true, types: ["party"] },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Actor, ryuutama.id, applications.sheets.actors.RyuutamaMonsterSheet,
-    { label: "RYUUTAMA.SHEETS.MonsterSheet", makeDefault: true, types: ["monster"] },
+    { label: "RYUUTAMA.SHEETS.ACTOR.MonsterSheet", makeDefault: true, types: ["monster"] },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.JournalEntryPage, ryuutama.id, applications.sheets.pages.ReferencePageSheet,
-    { label: "RYUUTAMA.SHEETS.ReferencePageSheet", makeDefault: true, types: ["reference"] },
+    { label: "RYUUTAMA.SHEETS.PAGE.ReferencePageSheet", makeDefault: true, types: ["reference"] },
   );
   foundry.applications.apps.DocumentSheetConfig.registerSheet(
     foundry.documents.Combatant, ryuutama.id, applications.sheets.combatants.RyuutamaCombatantSheet,
-    { label: "RYUUTAMA.SHEETS.CombatantSheet", makeDefault: true },
+    { label: "RYUUTAMA.SHEETS.COMBATANT.CombatantSheet", makeDefault: true },
   );
 
   // Register status effects.


### PR DESCRIPTION
- Rename "PhysicalData" to "EquippableData"
- Refactor i18n
- Set `inventory` in subtype metadata to default false, only true for equippable items.

Closes #348.