### PR TITLE
[#368] Prepare statuses and abilities during derived data stage

### DIFF
--- a/code/data/_types.d.ts
+++ b/code/data/_types.d.ts
@@ -10,7 +10,6 @@ import "./journal-entry-page/_types";
 
 declare module "./ability-model.mjs" {
   export default interface AbilityModel {
-    advancement: number;
     value: number;
   }
 }

--- a/code/data/ability-model.mjs
+++ b/code/data/ability-model.mjs
@@ -1,13 +1,60 @@
-const { NumberField } = foundry.data.fields;
-
 export default class AbilityModel extends foundry.abstract.DataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      advancement: new NumberField({ persisted: false, integer: true, initial: 0, min: 0 }),
       value: new ryuutama.data.fields.AbilityScoreField(),
     };
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Increases from advancements. Only used to track additions from this kind of source,
+   * not actually used in calculations, advancements should call `AbilityScoreField#increase`.
+   * A Stat Increase advancement requires this value to know what the "base" number is.
+   * @type {number}
+   */
+  advancement = 0;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * How many times has the denomination been decreased?
+   * @type {number}
+   */
+  decreases = 0;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * How many times has the denomination been increased?
+   * @type {number}
+   */
+  increases = 0;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Has the denomination been overridden? When overridden, increases and decreases no longer apply.
+   * @type {boolean}
+   */
+  overridden = false;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Minimum denomination from an upgrade change.
+   * @type {number|null}
+   */
+  minimum = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Maximum denomination from a downgrade change.
+   * @type {number|null}
+   */
+  maximum = null;
 
   /* -------------------------------------------------- */
 
@@ -34,5 +81,31 @@ export default class AbilityModel extends foundry.abstract.DataModel {
   /** @inheritdoc */
   toString() {
     return `1${this.die}`;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Determine denomination from a list of options.
+   * @param {number[]} options    The options for denominations, presented in order.
+   * @returns {number}
+   */
+  determineDenomination(options) {
+    if (this.overridden) return this.value;
+    options = [...options];
+    let value = this._source.value;
+    let delta = this.increases - this.decreases;
+
+    if (delta < 0) {
+      delta = -delta;
+      options.reverse();
+    }
+
+    const index = options.indexOf(value);
+    value = options[index + delta] ?? options.at(-1);
+    if (this.minimum) value = Math.max(value, this.minimum);
+    if (this.maximum) value = Math.min(value, this.maximum);
+
+    return value;
   }
 }

--- a/code/data/actor/templates/creature.mjs
+++ b/code/data/actor/templates/creature.mjs
@@ -168,8 +168,8 @@ export default class CreatureData extends BaseData {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  prepareBaseData() {
-    super.prepareBaseData();
+  prepareDerivedData() {
+    super.prepareDerivedData();
 
     this.#prepareStatuses();
     this._prepareAbilities();

--- a/code/data/actor/traveler.mjs
+++ b/code/data/actor/traveler.mjs
@@ -150,6 +150,8 @@ export default class TravelerData extends CreatureData {
 
   /** @inheritdoc */
   prepareBaseData() {
+    super.prepareBaseData();
+
     this.classes = Object.fromEntries(this.parent.items.documentsByType.class.map(cls => [cls.identifier, cls]));
 
     // Add a +1 bonus from a critical travel check. TODO: Consider moving to AE.
@@ -157,13 +159,8 @@ export default class TravelerData extends CreatureData {
 
     const { habitat = [], statusImmunity = [], type = [], weapon = [] } = this.advancements.documentsByType;
 
-    // Status immunities are prepared prior to statuses in CreatureData.
-    statusImmunity.forEach(a => this.#prepareStatusImmunityAdvancement(a));
-
-    super.prepareBaseData();
-
-    // Habitats, Types, and Mastered Weapons.
     habitat.forEach(a => this.#prepareHabitatAdvancement(a));
+    statusImmunity.forEach(a => this.#prepareStatusImmunityAdvancement(a));
     type.forEach(a => this.#prepareTypeAdvancement(a));
     weapon.forEach(a => this.#prepareWeaponAdvancement(a));
   }
@@ -249,7 +246,7 @@ export default class TravelerData extends CreatureData {
       if (!advancement.isConfigured) continue;
       const ability = advancement.choice.chosen;
       this.schema.getField(`abilities.${ability}.value`).increase(this.parent, 1);
-      this.abilities[ability].advancement += 1;
+      this.abilities[ability].advancement++;
     }
 
     if (this.condition.value >= 10) {
@@ -427,12 +424,15 @@ export default class TravelerData extends CreatureData {
     }
 
     const actor = this.parent;
+
     if (actor._advancing) {
       throw new Error("Actor is already in the process of advancing!");
     }
+
+    const clone = actor.clone({ effects: _replace([]) }, { keepId: true });
     actor._advancing = true;
 
-    const results = await ryuutama.applications.apps.actors.AdvancementDialog.create(actor, { level: level + 1 });
+    const results = await ryuutama.applications.apps.actors.AdvancementDialog.create(clone, { level: level + 1 });
     if (!results) {
       delete actor._advancing;
       return null;

--- a/code/data/advancement/stat-increase.mjs
+++ b/code/data/advancement/stat-increase.mjs
@@ -51,11 +51,9 @@ export default class StatIncreaseAdvancement extends Advancement {
     await super._prepareAdvancementContext(context, options);
 
     const getScore = ability => {
-      let base = context.actor.system._source.abilities[ability].value;
+      const base = context.actor.system.abilities[ability]._source.value;
       const steps = context.actor.system.abilities[ability].advancement;
-      const field = context.actor.system.schema.getField(`abilities.${ability}.value`);
-      for (let i = 0; i < steps; i++) base = field._applyChangeAdd(base, 1);
-      return base;
+      return base + 2 * steps;
     };
 
     context.abilityOptions = Object.entries(ryuutama.CONST.ABILITIES._toConfig)

--- a/code/data/fields/ability-score-field.mjs
+++ b/code/data/fields/ability-score-field.mjs
@@ -1,4 +1,5 @@
 /**
+ * @import AbilityModel from "../ability-model.mjs";
  * @import RyuutamaActor from "../../documents/actor.mjs";
  */
 
@@ -84,30 +85,27 @@ export default class AbilityScoreField extends NumberField {
 
   /** @inheritdoc */
   _applyChangeAdd(value, delta, model, change) {
-    if (![-1, 1].includes(delta)) return value;
-
-    let options = this.baseOptions;
-    if (delta === -1) options = options.toReversed();
-
-    const index = options.indexOf(value);
-    if (index === -1) return 4;
-
-    return options[index + 1] ?? options.at(-1);
+    /** @type {AbilityModel} */
+    const ability = model.system.abilities[this.parent.name];
+    switch (delta) {
+      case -1:
+        ability.decreases++;
+        break;
+      case 1:
+        ability.increases++;
+        break;
+      default:
+        return value;
+    }
+    return ability.determineDenomination(this.baseOptions);
   }
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
   _applyChangeSubtract(value, delta, model, change) {
-    if (![-1, 1].includes(delta)) return value;
-
-    let options = this.baseOptions;
-    if (delta === 1) options = options.toReversed();
-
-    const index = options.indexOf(value);
-    if (index === -1) return 4;
-
-    return options[index + 1] ?? options.at(-1);
+    if ([-1, 1].includes(delta)) return this._applyChangeAdd(value, -delta, model, change);
+    return value;
   }
 
   /* -------------------------------------------------- */
@@ -115,6 +113,7 @@ export default class AbilityScoreField extends NumberField {
   /** @inheritdoc */
   _applyChangeOverride(value, delta, model, change) {
     if (!this.#values.includes(delta)) return value;
+    model.system.abilities[this.parent.name].overridden = true;
     return delta;
   }
 
@@ -131,7 +130,11 @@ export default class AbilityScoreField extends NumberField {
   _applyChangeUpgrade(value, delta, model, change) {
     const options = this.baseOptions;
     if (!options.includes(delta)) return value;
-    return Math.max(value, delta);
+    /** @type {AbilityModel} */
+    const ability = model.system.abilities[this.parent.name];
+    ability.minimum = delta;
+    if (ability.maximum < ability.minimum) ability.maximum = null;
+    return ability.determineDenomination(options);
   }
 
   /* -------------------------------------------------- */
@@ -140,6 +143,10 @@ export default class AbilityScoreField extends NumberField {
   _applyChangeDowngrade(value, delta, model, change) {
     const options = this.baseOptions;
     if (!options.includes(delta)) return value;
-    return Math.min(value, delta);
+    /** @type {AbilityModel} */
+    const ability = model.system.abilities[this.parent.name];
+    ability.maximum = delta;
+    if (ability.minimum > ability.maximum) ability.minimum = null;
+    return ability.determineDenomination(options);
   }
 }

--- a/wiki/Active Effects Guide.md
+++ b/wiki/Active Effects Guide.md
@@ -4,9 +4,9 @@ Effects can perform changes to characters and monsters. The most commonly used a
 
 ## Abilities
 
-For example `system.abilities.strength.value | Add | 1` to increase the die size of the Strength stat to the next size up, to a maximum of 12. The system handles validating that the stats remain within 4 to 12; `Unit` can be either `-1` or `1` to decrease or increase the size, respectively.
+For example `system.abilities.strength.value | Add | 1` to increase the dice denomination of the Strength stat to the next size up, to a maximum of 12. The system handles validating that the stats remain within 4 to 12 for Travelers but allow 2 and 20 for Monsters; `Unit` can be either `-1` or `1` to decrease or increase the size, respectively (with inverted behavior for the `Subtract` change type).
 
-The `Override` mode can be used to force the ability to be any of the valid die sizes; 2, 4, 6, 8, 10, 12, and 20.
+The `Override` change type can be used to force the ability to be any of the valid die sizes (2, 4, 6, 8, 10, 12, and 20), and similarly the `Upgrade` and `Downgrade` change types enforce a minimum or maximum denomination.
 
 The valid ability keys are `strength`, `dexterity`, `intelligence`, and `spirit`.
 
@@ -14,6 +14,7 @@ Attribute Key | Mode | Value
 :- | :-: | :-:
 `system.abilities.<ability>.value` | Add | Unit
 `system.abilities.<ability>.value` | Override | Faces
+`system.abilities.<ability>.value` | Upgrade | Faces
 
 ## Capacity
 


### PR DESCRIPTION
Closes #368. Closes #356.

- CreatureData no longer has any base data prep.
- CreatureData prepares statuses and then abilities in derived data.
- TravelerData prepares classes, condition.travel, and anything from advancements (habitat, immunities, type, weapon).

Effects then apply before abilities are prepared, resolving #368.

Additional changes:

- The AdvancementDialog is constructed with a clone with no effects, meaning eg StatIncreaseAdvancement can be simplified.
- AbilityScoreField stores `decreases` and `increases` on the parent AbilityModel, as well as minimum and maximum when using upgrade/downgrade AE change types.
- The AbilityModel re-calculates the final value with each change.
- The non-persisted `advancement: number` field is moved out of the model, since it had no business being affected by AEs.

When using add/subtract, increases and subtractions are tracked and the final tally resolves to the die denomination. When using upgrade/downgrade, a minimum or maximum for the denomination is set; this doesn't adhere to priority. When using override, the die denomination is forced, ignoring other changes.