### PR TITLE
[#371] Add effect registry to track and expire dependent effects, items, and regions.

### DIFF
--- a/code/documents/_module.mjs
+++ b/code/documents/_module.mjs
@@ -7,6 +7,7 @@ export { default as RyuutamaCombatantGroup } from "./combatant-group.mjs";
 export { default as RyuutamaItem } from "./item.mjs";
 export { default as RyuutamaJournalEntry } from "./journal-entry.mjs";
 export { default as RyuutamaJournalEntryPage } from "./journal-entry-page.mjs";
+export { default as RyuutamaRegionDocument } from "./region.mjs";
 export { default as RyuutamaScene } from "./scene.mjs";
 export { default as RyuutamaTokenDocument } from "./token.mjs";
 

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -85,4 +85,73 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
     if (!data.type || (data.type === "base")) data.type = "standard";
     return super._initializeSource(data, options);
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    ryuutama.helpers.registries.EffectDependencyRegistry._registerDependent(this);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preDelete(options, user) {
+    if ((await super._preDelete(options, user)) === false) return false;
+
+    // This is a dependent effect being deleted.
+    if (options.dependentDeletionDesignatedUser || options.isDependentDeletion) return;
+
+    // Designate User to perform deletion of dependents.
+    const designatedUser = ryuutama.helpers.registries.EffectDependencyRegistry._getDesignatedUser(this);
+    if (designatedUser === false) {
+      // A user was needed but no designated user was found.
+      ui.notifications.warn("RYUUTAMA.EFFECT.unableToDeleteDueToDependents", { format: { effect: this.name } });
+      return false;
+    } else if (designatedUser === null) {
+      // No designated user was needed.
+      return;
+    } else {
+      // A designated User was found.
+      options.dependentDeletionDesignatedUser = designatedUser.id;
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+
+    if ((options.dependentDeletionDesignatedUser === userId) && !options.isDependentDeletion) {
+      ryuutama.helpers.registries.EffectDependencyRegistry._expireDependents(this);
+    }
+
+    // Remove from registry *after* expiration.
+    ryuutama.helpers.registries.EffectDependencyRegistry._unregister(this);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async deleteDialog(options = {}, operation = {}) {
+    let message;
+    const user = ryuutama.helpers.registries.EffectDependencyRegistry._getDesignatedUser(this);
+    switch (user) {
+      case false:
+        message = _loc("RYUUTAMA.EFFECT.unableToDeleteDueToDependents", { effect: this.name });
+        foundry.utils.setProperty(options, "yes.disabled", true);
+        break;
+      case null:
+        return super.deleteDialog(options, operation);
+      default:
+        message = _loc("RYUUTAMA.EFFECT.willAlsoDeleteDependents");
+    }
+
+    options.render = (event, dialog) => {
+      dialog.element.querySelector(".dialog-content").insertAdjacentHTML("beforeend", `<p>${message}</p>`);
+    };
+    return super.deleteDialog(options, operation);
+  }
 }

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -150,6 +150,14 @@ export default class RyuutamaItem extends foundry.documents.Item {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    ryuutama.helpers.registries.EffectDependencyRegistry._registerDependent(this);
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Render old and new containers.
    * @param {string} [formerStorage]    Uuid of a former container to re-render.

--- a/code/documents/region.mjs
+++ b/code/documents/region.mjs
@@ -1,0 +1,11 @@
+/**
+ * System implementation of the RegionDocument document class.
+ * @extends foundry.documents.RegionDocument
+ */
+export default class RyuutamaRegionDocument extends foundry.documents.RegionDocument {
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    ryuutama.helpers.registries.EffectDependencyRegistry._registerDependent(this);
+  }
+}

--- a/code/helpers/registries/_module.mjs
+++ b/code/helpers/registries/_module.mjs
@@ -1,2 +1,3 @@
 export { default as BaseRegistry } from "./registry.mjs";
+export { default as EffectDependencyRegistry } from "./effect-dependency-registry.mjs";
 export { default as SpellRegistry } from "./spells.mjs";

--- a/code/helpers/registries/effect-dependency-registry.mjs
+++ b/code/helpers/registries/effect-dependency-registry.mjs
@@ -1,0 +1,185 @@
+/**
+ * @import RyuutamaActiveEffect from "../../documents/active-effect.mjs";
+ * @import RyuutamaItem from "../../documents/item.mjs";
+ * @import RyuutamaRegionDocument from "../../documents/region.mjs";
+ * @import User from "@client/documents/user.mjs";
+ */
+
+/**
+ * @typedef EffectDependents
+ * @property {Set<string>} [ActiveEffect]     Uuids of dependent effects.
+ * @property {Set<string>} [Item]             Uuids of dependent items.
+ * @property {Set<string>} [Region]           Uuids of dependent regions.
+ *
+ * @typedef EffectDependentDocuments
+ * @property {Set<RyuutamaActiveEffect>} [ActiveEffect]   Dependent effects.
+ * @property {Set<RyuutamaItem>} [Item]                   Dependent items.
+ * @property {Set<RyuutamaRegionDocument>} [Region]       Dependent regions.
+ *
+ * @typedef {RyuutamaActiveEffect|RyuutamaItem|RyuutamaRegionDocument} RegisterableDocument
+ */
+
+/**
+ * A static class that holds onto entries for dependency relations between effects and
+ * their dependent items, regions, and other effects.
+ */
+export default class EffectDependencyRegistry {
+  /**
+   * The uuids of effects and their dependent documents.
+   * @type {Map<string, EffectDependents>}
+   */
+  static #effects = new Map();
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Register a dependent document.
+   * @param {RegisterableDocument} document
+   */
+  static _registerDependent(document) {
+    if (!["ActiveEffect", "Item", "Region"].includes(document.documentName)) return;
+    if (!document.isEmbedded) return; // Deleting documents from the world directories is not supported.
+    const uuid = document.getFlag(ryuutama.id, "dependency.parent");
+    const dependency = fromUuidSync(uuid);
+    if (!(dependency instanceof ryuutama.documents.RyuutamaActiveEffect) || !dependency.isEmbedded) return;
+
+    const registered = EffectDependencyRegistry.#effects.getOrInsert(dependency.uuid, {});
+    registered[document.documentName] ??= new Set();
+    registered[document.documentName].add(document.uuid);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * When an effect is deleted, remove its entry from the registry.
+   * @param {RyuutamaActiveEffect} effect   The deleted effect.
+   */
+  static _unregister(effect) {
+    EffectDependencyRegistry.#effects.delete(effect.uuid);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Recursively retrieve dependent documents of an ActiveEffect.
+   * @param {RyuutamaActiveEffect} effect   The effect.
+   * @returns {EffectDependentDocuments}
+   */
+  static #getDependents(effect) {
+    const dependents = {};
+
+    const mainEffects = new Set();
+
+    const getDependents = effect => {
+      if (mainEffects.has(effect)) return; // Prevent recursion.
+      mainEffects.add(effect);
+      const d = EffectDependencyRegistry.#effects.get(effect.uuid) ?? {};
+      return Object.entries(d).reduce((acc, [documentName, uuids]) => {
+        const documents = Array.from(uuids).map(uuid => fromUuidSync(uuid));
+        const isDependent = documents.filter(doc => EffectDependencyRegistry.#isDependent(doc, effect));
+        if (isDependent.length) acc[documentName] = new Set(isDependent);
+        return acc;
+      }, {});
+    };
+
+    const recursion = effect => {
+      const d = getDependents(effect);
+      if (foundry.utils.isEmpty(d)) return;
+
+      for (const [dName, docs] of Object.entries(d)) {
+        dependents[dName] ??= new Set();
+        docs.forEach(d => dependents[dName].add(d));
+      }
+
+      for (const e of d.ActiveEffect ?? []) recursion(e);
+    };
+
+    recursion(effect);
+
+    return dependents;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is the document dependent on a given effect?
+   * @param {foundry.abstract.Document} document    The dependent.
+   * @param {RyuutamaActiveEffect} effect           The effect dependency.
+   * @returns {boolean}
+   */
+  static #isDependent(document, effect) {
+    if (effect.inCompendium) return false;
+    if (!document || !(document instanceof foundry.abstract.Document) || document.inCompendium) return false;
+    return document.getFlag(ryuutama.id, "dependency.parent") === effect.uuid;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Which User is able to delete all the dependents?
+   * @param {RyuutamaActiveEffect} effect   The effect with dependents.
+   * @returns {User|null|false}             The User able to delete all dependents, or `null` if no User was needed,
+   *                                        or `false` if a User was needed but none was found.
+   */
+  static _getDesignatedUser(effect) {
+    const dependents = EffectDependencyRegistry.#getDependents(effect);
+    if (foundry.utils.isEmpty(dependents)) return null;
+
+    const allowed = user => user.active && Object.values(dependents)
+      .every(documents => documents.every(document => document.canUserModify(user, "delete")));
+
+    const user = game.users.getDesignatedUser(allowed);
+    if (!user) return false; // A User was needed but none was found.
+    return user;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Delete documents that are dependent on an effect.
+   * @param {RyuutamaActiveEffect} effect                     The effect.
+   * @returns {Promise<foundry.abstract.Document[][]|null>}   A promise that resolves to the deleted documents.
+   */
+  static async _expireDependents(effect) {
+    const dependents = EffectDependencyRegistry.#getDependents(effect);
+
+    const batches = [];
+    Object.entries(dependents).forEach(([documentName, documents]) => {
+      documents.forEach(document => {
+        batches.push({
+          action: "delete",
+          ids: [document.id],
+          parent: document.parent,
+          isDependentDeletion: true,
+          documentName,
+        });
+      });
+    });
+
+    return foundry.documents.modifyBatch(batches);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Mark a document to be dependent on an effect.
+   * @param {RegisterableDocument} document
+   * @param {RyuutamaActiveEffect} effect   The dependency effect.
+   * @returns {Promise<boolean>}
+   */
+  static async registerDependency(document, effect) {
+    const isValid = ["ActiveEffect", "Item", "Region"].includes(document.documentName)
+      && (effect.documentName === "ActiveEffect")
+      && (document.uuid !== effect.uuid)
+      && document.isEmbedded && effect.isEmbedded
+      && !document.inCompendium && !effect.inCompendium;
+
+    if (!isValid) {
+      console.error("Invalid parameters provided for assigning dependency.");
+      return false;
+    }
+
+    await document.setFlag(ryuutama.id, "dependency.parent", effect.uuid);
+    return true;
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -503,7 +503,10 @@
         },
         "configureStrength": "Configure Strength",
         "noActors": "No controlled tokens' actors were valid for application of this status."
-      }
+      },
+
+      "unableToDeleteDueToDependents": "Unable to delete effect {effect} as it has dependents that no active user are able to remove.",
+      "willAlsoDeleteDependents": "Removing this Active Effect will also remove dependent effects, items, and regions."
     },
 
     "HABITAT": {

--- a/main.mjs
+++ b/main.mjs
@@ -106,6 +106,8 @@ Hooks.once("init", () => {
   CONFIG.JournalEntryPage.documentClass = documents.RyuutamaJournalEntryPage;
   CONFIG.JournalEntryPage.dataModels.reference = data.journalEntryPage.ReferenceData;
 
+  CONFIG.Region.documentClass = documents.RyuutamaRegionDocument;
+
   CONFIG.Scene.documentClass = documents.RyuutamaScene;
 
   CONFIG.Token.documentClass = documents.RyuutamaTokenDocument;


### PR DESCRIPTION
Adds a new registry class found in `ryuutama.helpers.registries.EffectDependencyRegistry`.

Effects, items, and regions store their uuids here if they have a flag provided. Users can assign this flag property with the registry's `EffectDependencyRegistry.registerDependency` method.

When a dependency ActiveEffect is deleted, its dependents are also deleted. This works recursively when effects are dependent on other effects, and the deletion is done in one operation.

In addition, users are prevented from deleting effects if they have dependents that no active user is able to remove, or if no single user is able to perform the entire deletion operation.

Closes #371.