### PR TITLE
[#151, #361] Effect configuration and statues on Action model

### DIFF
--- a/code/applications/api/document-sheet.mjs
+++ b/code/applications/api/document-sheet.mjs
@@ -369,6 +369,8 @@ export default class RyuutamaDocumentSheet extends HandlebarsApplicationMixin(Do
    * @returns {Promise}         Whether the drop was fully resolved, either truthy or falsy.
    */
   static async _onDrop(event) {
+    if (event.target.closest("document-tags")) return true;
+
     const { uuid } = CONFIG.ux.TextEditor.getDragEventData(event);
     const model = await fromUuid(uuid);
     if (!model) return false;

--- a/code/applications/sheets/items/item-sheet.mjs
+++ b/code/applications/sheets/items/item-sheet.mjs
@@ -7,7 +7,7 @@ import RyuutamaDocumentSheet from "../../api/document-sheet.mjs";
 export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
-    position: { width: 400 },
+    position: { width: 500 },
     window: {
       contentClasses: ["standard-form"],
     },
@@ -15,6 +15,7 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
       decreaseRation: RyuutamaItemSheet.#decreaseRation,
       increaseRation: RyuutamaItemSheet.#increaseRation,
       removeSkill: RyuutamaItemSheet.#removeSkill,
+      toggleActionEffectStatus: RyuutamaItemSheet.#toggleActionEffectStatus,
     },
   };
 
@@ -37,7 +38,8 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
     },
     actions: {
       template: "systems/ryuutama/templates/sheets/item-sheet/actions.hbs",
-      classes: ["tab", "scrollable", "standard-form"],
+      templates: ["templates/generic/tab-navigation.hbs"],
+      classes: ["tab", "standard-form"],
       scrollable: [""],
     },
     effects: {
@@ -59,6 +61,15 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
         { id: "effects" },
       ],
       initial: "identity",
+      labelPrefix: "RYUUTAMA.ITEM.TABS",
+    },
+    actions: {
+      tabs: [
+        { id: "actionDamage" },
+        { id: "actionHealing" },
+        { id: "actionEffects" },
+      ],
+      initial: "actionDamage",
       labelPrefix: "RYUUTAMA.ITEM.TABS",
     },
   };
@@ -98,6 +109,7 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
     const context = await super._prepareContext(options);
 
     Object.assign(context, {
+      tabs: this._prepareTabs("primary"),
       enriched: {
         description: await CONFIG.ux.TextEditor.enrichHTML(
           this.document.system.description.value,
@@ -124,15 +136,46 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
    * @param {object} context    Rendering context. **will be mutated**.
    */
   #prepareActions(context) {
-    context.actions = {
+    const a = context.actions = {
       document: this.document.system.actions,
       source: this.document.system.actions._source,
       fields: this.document.system.actions.schema.fields,
+      tabs: this._prepareTabs("actions"),
     };
 
-    context.actions.damageOptions = Object.keys(ryuutama.config.damageRollProperties)
+    a.damageOptions = Object.keys(ryuutama.config.damageRollProperties)
       .filter(key => !ryuutama.config.damageRollProperties[key].hidden)
       .map(key => ({ value: key, label: ryuutama.config.damageRollProperties[key].label }));
+
+    a.statuses = Object.values(ryuutama.CONST.STATUS_EFFECTS).map(status => {
+      const active = status in context.actions.document.effects.statuses;
+      const field = context.actions.document.schema.getField("effects.statuses.element.strength");
+      const name = field.fieldPath.replace("element", status);
+      return {
+        active, status, field, name,
+        strength: context.actions.document.effects.statuses[status]?.strength ?? null,
+        disabledInput: !active || context.disabled,
+        icon: active ? "fa-solid fa-fw fa-trash" : "fa-solid fa-fw fa-pen",
+        label: ryuutama.config.statusEffects[status].name,
+        display: active || !context.disabled,
+        id: [context.rootId, "-", name].join(""),
+      };
+    });
+
+    const groups = {
+      time: _loc("EFFECT.DURATION.UNITS.GROUPS.time"),
+      combat: _loc("EFFECT.DURATION.UNITS.GROUPS.combat"),
+    };
+
+    a.effectConfig = {
+      values: a.document.effects.config,
+      fields: a.document.schema.getField("effects.config").fields,
+      durationOptions: CONST.ACTIVE_EFFECT_DURATION_UNITS.map(unit => {
+        const label = _loc(`EFFECT.DURATION.UNITS.${unit}`);
+        const group = CONST.ACTIVE_EFFECT_TIME_DURATION_UNITS.includes(unit) ? groups.time : groups.combat;
+        return { label, group, value: unit };
+      }),
+    };
   }
 
   /* -------------------------------------------------- */
@@ -314,6 +357,14 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  async _onDropActiveEffect(event, effect) {
+    if (this.tabGroups.primary !== "effects") return true;
+    return super._onDropActiveEffect(event, effect);
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * @this RyuutamaItemSheet
    * @param {PointerEvent} event    The initiating click event.
@@ -348,5 +399,20 @@ export default class RyuutamaItemSheet extends RyuutamaDocumentSheet {
     const skills = this.document.system.toObject().skills;
     skills.findSplice(s => s.uuid === uuid);
     this.document.update({ "system.skills": skills });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this RyuutamaItemSheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #toggleActionEffectStatus(event, target) {
+    const status = target.closest("[data-status]").dataset.status;
+    const action = this.document.system.actions.effects.statuses;
+    this.document.update({
+      [`system.actions.effects.statuses.${status}`]: (status in action) ? _del : { strength: null },
+    });
   }
 }

--- a/code/data/_types.d.ts
+++ b/code/data/_types.d.ts
@@ -22,6 +22,20 @@ declare module "./actions-model.mjs" {
       formula: string;
       properties: Set<string>;
     }
+    effects: {
+      config: {
+        duration: {
+          units: string;
+          value: number | null;
+        }
+        riders: {
+          items: Set<string>;
+        }
+        self: boolean;
+        uuids: Set<string>;
+      }
+      statuses: Record<string, { strength: number }>;
+    }
     healing: {
       formula: string;
       properties: Set<string>;

--- a/code/data/actions-model.mjs
+++ b/code/data/actions-model.mjs
@@ -1,8 +1,13 @@
 /**
+ * @import { DatabaseWriteOperation } from "@common/abstract/_types.mjs";
+ * @import RyuutamaActor from "../documents/actor.mjs";
  * @import RyuutamaItem from "../documents/item.mjs";
  */
 
-const { SchemaField, SetField, StringField } = foundry.data.fields;
+const {
+  BooleanField, DocumentUUIDField, EmbeddedDataField, NumberField,
+  SchemaField, SetField, StringField, TypedObjectField,
+} = foundry.data.fields;
 
 /**
  * An embedded model for items that perform actions.
@@ -15,6 +20,7 @@ export default class ActionsModel extends foundry.abstract.DataModel {
         formula: new ryuutama.data.fields.FormulaField(),
         properties: new SetField(new StringField()),
       }),
+      effects: new EmbeddedDataField(EffectsModel),
       healing: new SchemaField({
         formula: new ryuutama.data.fields.FormulaField(),
         properties: new SetField(new StringField()),
@@ -48,10 +54,6 @@ export default class ActionsModel extends foundry.abstract.DataModel {
   async toMessagePartData() {
     const parts = [];
 
-    // Effects
-    const effects = await this.toEffectsPartData();
-    if (effects) parts.push(effects);
-
     // Damage
     const damage = await this.toDamagePartData();
     if (damage) parts.push(damage);
@@ -59,6 +61,10 @@ export default class ActionsModel extends foundry.abstract.DataModel {
     // Healing
     const healing = await this.toHealingPartData();
     if (healing) parts.push(healing);
+
+    // Effects
+    const effects = await this.toEffectsPartData();
+    if (effects) parts.push(effects);
 
     return Object.fromEntries(parts.map(part => [foundry.utils.randomID(), part]));
   }
@@ -70,7 +76,10 @@ export default class ActionsModel extends foundry.abstract.DataModel {
    * @returns {Promise<object|null>}
    */
   async toEffectsPartData() {
-    return null;
+    return {
+      type: "effect",
+      itemUuid: this.item.uuid,
+    };
   }
 
   /* -------------------------------------------------- */
@@ -104,5 +113,282 @@ export default class ActionsModel extends foundry.abstract.DataModel {
     await roll.evaluate();
     partData.rolls.push(roll);
     return partData;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Apply effects.
+   * @param {RyuutamaActor[]} [actors]
+   * @returns {Promise<void>}
+   */
+  async applyEffects(actors) {
+    if (!actors?.length) {
+      actors = new Set(canvas.tokens.controlled.map(token => token.actor).filter(_ => _));
+    }
+
+    const batches = [];
+    const toApply = await this.effects.toBatches(actors);
+    if (toApply) batches.push(...toApply);
+    await foundry.documents.modifyBatch(batches);
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data model which is responsible for data related to effects, riders, and application.
+ */
+class EffectsModel extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    const validateEffect = uuid => {
+      if (!uuid) return;
+      if (!uuid.startsWith("Compendium.")) {
+        throw new Error(_loc("RYUUTAMA.ITEM.ACTIONS.WARNINGS.effectPack"));
+      }
+    };
+
+    const validateItem = uuid => {
+      if (!uuid) return;
+      if (!uuid.startsWith("Compendium.")) {
+        throw new Error(_loc("RYUUTAMA.ITEM.ACTIONS.WARNINGS.itemPack"));
+      }
+
+      const item = fromUuidSync(uuid);
+      if (!item) return;
+
+      const valid = [
+        "weapon", "shield", "armor", "hat", "cape", "shoes",
+        "accessory", "staff", "herb", "container", "animal",
+      ].includes(item.type);
+      if (!valid) {
+        throw new Error(_loc("RYUUTAMA.ITEM.ACTIONS.WARNINGS.itemType", {
+          type: _loc(CONFIG.Item.typeLabels[item.type]),
+        }));
+      }
+    };
+
+    const statusKeys = Object.values(ryuutama.CONST.STATUS_EFFECTS);
+
+    return {
+      config: new SchemaField({
+        duration: new SchemaField({
+          units: new StringField({ choices: CONST.ACTIVE_EFFECT_DURATION_UNITS, initial: "seconds", required: true }),
+          value: new NumberField({ integer: true, min: 0, nullable: true, required: true }),
+        }),
+        riders: new SchemaField({
+          items: new SetField(new DocumentUUIDField({ type: "Item", embedded: false, validate: validateItem })),
+        }),
+        self: new BooleanField({ required: true, initial: false }),
+        uuids: new SetField(new DocumentUUIDField({ type: "ActiveEffect", embedded: false, validate: validateEffect })),
+      }),
+      statuses: new TypedObjectField(
+        new SchemaField({
+          strength: new NumberField({ min: 2, max: 20, integer: true, nullable: true, placeholder: "4", initial: 4 }),
+        }),
+        { validateKey: key => statusKeys.includes(key) },
+      ),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Will an effect created have a duration override?
+   * @type {boolean}
+   */
+  get hasDuration() {
+    return this.config.duration.value > 0;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Should a duration tracking effect be created in lieu of a primary effect?
+   * @type {boolean}
+   */
+  get _createPlaceholderDurationEffect() {
+    if (!this.hasDuration) return false;
+    return !this.config.uuids.size;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Will application of the config create a primary effect or duration tracking effect?
+   * @type {boolean}
+   */
+  get hasPrimaryEffect() {
+    return this._createPlaceholderDurationEffect || this.config.uuids.some(uuid => fromUuidSync(uuid));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetch rider items and effects.
+   * @returns {Promise<{ items: object[] }>}
+   */
+  async #retrieveRiders() {
+    const { Item = [] } = await Promise.all([
+      ...Array.from(this.config.riders.items).map(uuid => fromUuid(uuid)),
+    ]).then(results => Object.groupBy(results.filter(_ => _), rider => rider.documentName));
+    const items = await getDocumentClass("Item").createWithContents(Item);
+
+    return { items };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare the batches of database operations to apply effects, riders, and statuses.
+   * @param {Iterable<RyuutamaActor>} actors
+   * @returns {Promise<DatabaseWriteOperation[]|null>}
+   */
+  async toBatches(actors) {
+    const batches = [];
+    const effects = await this.#toBatchesConfiguration(actors);
+    const statuses = await this.#toBatchesStatuses(actors);
+
+    if (effects) batches.push(...effects);
+    if (statuses) batches.push(...statuses);
+
+    return batches.length ? batches : null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare batches of the effect alongside dependency relations to apply.
+   * @param {Iterable<RyuutamaActor>} actors
+   * @returns {Promise<object[]|null>}
+   */
+  async #toBatchesConfiguration(actors) {
+    if (!this.hasPrimaryEffect) return null;
+
+    const item = this.parent.item;
+    if (this.config.self) actors = [item.actor];
+
+    const makeDependency = async () => {
+      if (this._createPlaceholderDurationEffect) {
+        const ActiveEffect = getDocumentClass("ActiveEffect");
+        const dependency = new ActiveEffect({
+          name: _loc("RYUUTAMA.ITEM.ACTIONS.durationEffectName", { item: item.name }),
+          img: item.img,
+          type: "standard",
+          description: `<p>@Embed[${item.uuid} cite=false]</p>`,
+          duration: { ...this.config.duration },
+        });
+        return foundry.utils.mergeObject(dependency.toObject(), { origin: item.uuid });
+      }
+
+      let dependency;
+      const choices = Array.from(this.config.uuids).map(uuid => fromUuidSync(uuid)).filter(_ => _);
+      if (!choices.length) return null;
+
+      if (choices.length > 1) {
+        const options = choices.map((c, i) => {
+          return { value: c.uuid, label: c.name, uuid: c.uuid, checked: !i };
+        });
+        const result = await foundry.applications.api.Dialog.input({
+          content: await foundry.applications.handlebars.renderTemplate(
+            "systems/ryuutama/templates/chat/effect-select.hbs", {
+              options,
+              rootId: foundry.utils.randomID(),
+            },
+          ),
+          window: {
+            title: "RYUUTAMA.ITEM.ACTIONS.selectEffect",
+            icon: "fa-solid fa-person-rays",
+          },
+        });
+        dependency = await fromUuid(result?.dependency);
+      } else {
+        dependency = await fromUuid(choices[0].uuid);
+      }
+
+      if (!dependency) return null;
+      return foundry.utils.mergeObject(dependency.toObject(), {
+        "_stats.compendiumSource": dependency.uuid,
+        duration: this.hasDuration ? { ...this.config.duration } : {},
+        origin: item.uuid,
+      });
+    };
+
+    const dependency = await makeDependency();
+    if (!dependency) return null;
+
+    const { items } = await this.#retrieveRiders();
+    const batches = [];
+
+    for (const parent of actors) {
+      const id = foundry.utils.randomID();
+      const uuid = foundry.utils.buildUuid({ id, parent, documentName: "ActiveEffect" });
+
+      batches.push({
+        parent,
+        action: "create",
+        data: [foundry.utils.mergeObject(dependency, { _id: id }, { inplace: false })],
+        documentName: "ActiveEffect",
+        keepId: true,
+        noHook: true,
+      }, {
+        parent,
+        action: "create",
+        data: items,
+        dependencyUuid: uuid,
+        documentName: "Item",
+        keepId: true, // allowed due to `createWithContents`
+        noHook: true,
+      });
+    }
+
+    return batches.length ? batches : null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare batches of statuses to apply to actors.
+   * @param {Iterable<RyuutamaActor>} actors
+   * @returns {Promise<object[]|null>}
+   */
+  async #toBatchesStatuses(actors) {
+    const batches = [];
+    const ActiveEffect = getDocumentClass("ActiveEffect");
+
+    const byStatus = {};
+
+    for (const parent of actors) {
+      const toCreate = [];
+      const toUpdate = [];
+      for (const [status, { strength }] of Object.entries(this.statuses)) {
+        const effect = byStatus[status] ??= await ActiveEffect.fromStatusEffect(status, { strength });
+        if (parent.effects.has(effect.id)) {
+          const str = parent.effects.get(effect.id).system.strength;
+          if (str < strength) toUpdate.push({ _id: effect.id, system: _replace(effect.toObject().system) });
+        } else {
+          toCreate.push(effect.toObject());
+        }
+      }
+
+      if (toCreate.length) batches.push({
+        parent,
+        action: "create",
+        data: toCreate,
+        documentName: "ActiveEffect",
+        keepId: true,
+        noHook: true,
+      });
+
+      if (toUpdate.length) batches.push({
+        parent,
+        action: "update",
+        documentName: "ActiveEffect",
+        noHook: true,
+        updates: toUpdate,
+      });
+    }
+    return batches.length ? batches : null;
   }
 }

--- a/code/data/chat-message/parts/_types.d.ts
+++ b/code/data/chat-message/parts/_types.d.ts
@@ -30,8 +30,7 @@ declare module "./damage.mjs" {
 
 declare module "./effect.mjs" {
   export default interface EffectPart {
-    effects: string[];
-    statuses: Record<string, number>;
+    itemUuid: string;
   }
 }
 

--- a/code/data/chat-message/parts/effect.mjs
+++ b/code/data/chat-message/parts/effect.mjs
@@ -1,11 +1,10 @@
 import MessagePart from "./base.mjs";
 
 /**
- * @import RyuutamaActor from "../../../documents/actor.mjs";
- * @import RyuutamaActiveEffect from "../../../documents/active-effect.mjs";
+ * @import RyuutamaItem from "../../../documents/item.mjs";
  */
 
-const { ArrayField, DocumentUUIDField, NumberField, TypedObjectField } = foundry.data.fields;
+const { DocumentUUIDField } = foundry.data.fields;
 
 export default class EffectPart extends MessagePart {
   static {
@@ -29,47 +28,25 @@ export default class EffectPart extends MessagePart {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      effects: new ArrayField(new DocumentUUIDField({ embedded: true, type: "ActiveEffect" })),
-      statuses: new TypedObjectField(
-        new NumberField({ min: 2, max: 20, integer: true, nullable: false, initial: 4 }),
-        { validateKey: key => Object.values(ryuutama.CONST.STATUS_EFFECTS).includes(key) },
-      ),
+      itemUuid: new DocumentUUIDField({ type: "Item", embedded: true }),
     });
   }
 
   /* -------------------------------------------------- */
 
   /**
-   * The damage configs that will be applied by this message.
-   * @type {RyuutamaActiveEffect[]}
+   * The item used.
+   * @type {RyuutamaItem|null}
    */
-  get appliedEffects() {
-    return this.effects.map(uuid => fromUuidSync(uuid)).filter(_ => _);
+  get item() {
+    return fromUuidSync(this.itemUuid);
   }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * The statuses to be applied.
-   * @type {Record<string, number>}
-   */
-  get appliedStatuses() {
-    return foundry.utils.deepClone(this.statuses);
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Effects and statuses to ignore. Storing either uuids or status ids.
-   * @type {Set<string>}
-   */
-  #ignoredEffects = new Set();
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
   get visible() {
-    return game.user.isGM;
+    return game.user.isGM || (this.item?.system.actions.effects.config.self ?? false);
   }
 
   /* -------------------------------------------------- */
@@ -77,20 +54,9 @@ export default class EffectPart extends MessagePart {
   /** @inheritdoc */
   async _prepareContext(context) {
     await super._prepareContext(context);
-    context.ctx.effects = this.appliedEffects.map(effect => {
-      return {
-        effect,
-        checked: !this.#ignoredEffects.has(effect.uuid),
-      };
-    });
-    context.ctx.statuses = Object.entries(this.appliedStatuses).map(([statusId, strength]) => {
-      return {
-        statusId, strength,
-        label: ryuutama.config.statusEffects[statusId].name,
-        icon: ryuutama.config.statusEffects[statusId].img,
-        checked: !this.#ignoredEffects.has(statusId),
-      };
-    });
+    const item = this.item;
+    const { statuses, config } = item?.system.actions.effects ?? {};
+    context.ctx.showTray = !!item && (!config.self || !foundry.utils.isEmpty(statuses));
   }
 
   /* -------------------------------------------------- */
@@ -98,15 +64,6 @@ export default class EffectPart extends MessagePart {
   /** @inheritdoc */
   _addListeners(html, context) {
     super._addListeners(html, context);
-
-    for (const input of html.querySelectorAll("input[type=checkbox]")) {
-      input.addEventListener("change", () => {
-        const div = input.closest(".effect");
-        const id = div.dataset.effectUuid ?? div.dataset.statusId;
-        if (input.checked) this.#ignoredEffects.delete(id);
-        else this.#ignoredEffects.add(id);
-      });
-    }
   }
 
   /* -------------------------------------------------- */
@@ -118,78 +75,7 @@ export default class EffectPart extends MessagePart {
    * @param {HTMLElement} target    The capturing element that defined the [data-action].
    */
   static async #applyEffects(event, target) {
-    const element = target.closest("[data-message-part]");
-    const effects = this.appliedEffects.filter(effect => !this.#ignoredEffects.has(effect.uuid));
-    const statuses = this.appliedStatuses;
-    for (const k in statuses) if (this.#ignoredEffects.has(k)) delete statuses[k];
-    for (const actorElement of element.querySelectorAll("effect-tray [data-actor-uuid]")) {
-      const actor = fromUuidSync(actorElement.dataset.actorUuid);
-      EffectPart.applyEffects(actor, effects, statuses);
-    }
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Apply effects to one actor.
-   * @param {RyuutamaActor} actor
-   * @param {RyuutamaActiveEffect[]} effects
-   * @param {Record<string, number>} statuses
-   * @returns {Promise}
-   */
-  static async applyEffects(actor, effects, statuses) {
-    const toDelete = [];
-    const toCreate = [];
-
-    effects.forEach(effect => {
-      const existing = actor.effects.find(e => e.origin === effect.uuid);
-      if (existing) toDelete.push(existing.id);
-      const data = effect.toObject();
-      data.origin = effect.uuid;
-      toCreate.push(data);
-    });
-
-    const updateStatuses = [];
-    const createStatuses = [];
-    for (const [status, strength] of Object.entries(statuses)) {
-      const effect = await getDocumentClass("ActiveEffect").fromStatusEffect(status, { strength });
-      if (actor.effects.has(effect.id)) {
-        updateStatuses.push({ _id: effect.id, system: _replace(effect.toObject().system) });
-      } else {
-        createStatuses.push(effect.toObject());
-      }
-    }
-
-    return foundry.documents.modifyBatch([
-      {
-        action: "delete",
-        parent: actor,
-        documentName: "ActiveEffect",
-        ids: toDelete,
-      },
-      {
-        action: "create",
-        parent: actor,
-        documentName: "ActiveEffect",
-        data: toCreate,
-      },
-
-      // Statuses
-      {
-        action: "update",
-        updates: updateStatuses,
-        documentName: "ActiveEffect",
-        parent: actor,
-        diff: false,
-        recursive: false,
-      },
-      {
-        action: "create",
-        data: createStatuses,
-        documentName: "ActiveEffect",
-        parent: actor,
-        keepId: true,
-      },
-    ]);
+    const item = this.item;
+    item.system.actions.applyEffects();
   }
 }

--- a/code/documents/active-effect.mjs
+++ b/code/documents/active-effect.mjs
@@ -79,6 +79,12 @@ export default class RyuutamaActiveEffect extends foundry.documents.ActiveEffect
   async _preCreate(data, options, user) {
     if ((await super._preCreate(data, options, user)) === false) return false;
     if (this.parent?.type === "party") return false;
+
+    if (options.dependencyUuid) {
+      const { type } = foundry.utils.parseUuid(options.dependencyUuid) ?? {};
+      if (type === "ActiveEffect")
+        this.updateSource({ [`flags.${ryuutama.id}.dependency.parent`]: options.dependencyUuid });
+    }
   }
 
   /* -------------------------------------------------- */

--- a/code/documents/item.mjs
+++ b/code/documents/item.mjs
@@ -47,11 +47,11 @@ export default class RyuutamaItem extends foundry.documents.Item {
   /**
    * Create items with respect to containers and their contents. This returns item data,
    * which should be used with `Item.createDocuments` with `keepId: true`.
-   * @param {RyuutamaItem[]} items              The items to create.
+   * @param {RyuutamaItem[]} items                              The items to create.
    * @param {object} [options]
    * @param {RyuutamaItem} [options.storage]                    A container to place the items in.
    * @param {(RyuutamaItem) => object} [options.transformer]    Method to use when preparing and cleaning the items.
-   * @returns {Promise<object[]>}               Data for items to be created.
+   * @returns {Promise<object[]>}                               Data for items to be created.
    */
   static async createWithContents(items, { storage, transformer } = {}) {
     let { containers = [], physical = [], other = [] } = Object.groupBy(items, item => {
@@ -111,6 +111,12 @@ export default class RyuutamaItem extends foundry.documents.Item {
   async _preCreate(data, options, user) {
     if ((await super._preCreate(data, options, user)) === false) return false;
     if (this.parent?.type === "party") return false;
+
+    if (options.dependencyUuid) {
+      const { type } = foundry.utils.parseUuid(options.dependencyUuid) ?? {};
+      if (type === "ActiveEffect")
+        this.updateSource({ [`flags.${ryuutama.id}.dependency.parent`]: options.dependencyUuid });
+    }
   }
 
   /* -------------------------------------------------- */

--- a/code/documents/region.mjs
+++ b/code/documents/region.mjs
@@ -8,4 +8,17 @@ export default class RyuutamaRegionDocument extends foundry.documents.RegionDocu
     super.prepareDerivedData();
     ryuutama.helpers.registries.EffectDependencyRegistry._registerDependent(this);
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+
+    if (options.dependencyUuid) {
+      const { type } = foundry.utils.parseUuid(options.dependencyUuid) ?? {};
+      if (type === "ActiveEffect")
+        this.updateSource({ [`flags.${ryuutama.id}.dependency.parent`]: options.dependencyUuid });
+    }
+  }
 }

--- a/code/helpers/registries/effect-dependency-registry.mjs
+++ b/code/helpers/registries/effect-dependency-registry.mjs
@@ -147,11 +147,14 @@ export default class EffectDependencyRegistry {
     Object.entries(dependents).forEach(([documentName, documents]) => {
       documents.forEach(document => {
         batches.push({
+          documentName,
           action: "delete",
           ids: [document.id],
           parent: document.parent,
+          // Do not delete contents of containers; if a container was added as a dependent,
+          // then its contents were also each added as dependents.
+          deleteContents: false,
           isDependentDeletion: true,
-          documentName,
         });
       });
     });

--- a/lang/en.json
+++ b/lang/en.json
@@ -528,12 +528,45 @@
       "ACTIONS": {
         "FIELDS": {
           "damage.formula.label": "Formula",
+          "damage.formula.placeholder": "E.g. '@stats.spirit'",
           "damage.properties.label": "Properties",
           "healing.formula.label": "Formula",
-          "healing.properties.label": "Properties"
+          "healing.formula.placeholder": "E.g. '@stats.spirit'",
+          "healing.properties.label": "Properties",
+          "effects.config": {
+            "uuids": {
+              "label": "Primary Effect",
+              "hint": "The effect that will be applied. If multiple effects are referenced here, you choose one effect when applying."
+            },
+            "self": {
+              "label": "Apply to Self",
+              "hint": "If checked, the primary effect and riders are immediately granted to the actor using this item without requiring their selection."
+            },
+            "riders": {
+              "items": {
+                "label": "Rider Items",
+                "hint": "Riders will be granted to the target in addition to the primary effect and will be removed when the primary effect is removed."
+              }
+            }
+          }
         },
+
+        "WARNINGS": {
+          "effectPack": "The ActiveEffect must exist in a Compendium.",
+          "itemPack": "The Item must exist in a Compendium.",
+          "itemType": "An Item of type '{type}' cannot be linked to a granted effect."
+        },
+
+        "effectApplied": "Applied Effects",
         "damage": "Damage",
-        "healing": "Healing"
+        "durationEffectName": "Duration: {item}",
+        "durationHint": "A duration will override the default duration of the Primary Effect. If a Primary Effect is omitted, a more generic effect is created to track the duration.",
+        "durationLabel": "Duration",
+        "healing": "Healing",
+        "selectEffect": "Select Effect",
+        "selectEffectHint": "Select which option to apply.",
+        "statuses": "Statuses",
+        "statusesHint": "Configure statuses that are applied by this item."
       },
 
       "CONTEXT": {
@@ -541,7 +574,7 @@
           "edit": "Edit Effect",
           "delete": "Delete Effect",
           "disable": "Disable Effect",
-          "enable":"Enable Effect"
+          "enable": "Enable Effect"
         },
         "ITEM": {
           "delete": "Delete Item",
@@ -582,12 +615,14 @@
       },
 
       "TABS": {
+        "actionDamage": "Damage",
+        "actionEffects": "Effects",
+        "actionHealing": "Healing",
         "actions": "Actions",
         "details": "Details",
         "effects": "Effects",
         "identity": "Identity"
       },
-
       "activeEffects": "Active",
       "defenses": "Defenses",
       "description": "Description",

--- a/main.mjs
+++ b/main.mjs
@@ -61,6 +61,7 @@ Hooks.once("init", () => {
   CONFIG.ActiveEffect.documentClass = documents.RyuutamaActiveEffect;
   CONFIG.ActiveEffect.dataModels.standard = data.effect.StandardData;
   CONFIG.ActiveEffect.dataModels.status = data.effect.StatusData;
+  CONFIG.ActiveEffect.expiryAction = "delete";
 
   CONFIG.Actor.collection = documents.collections.RyuutamaActors;
   CONFIG.Actor.documentClass = documents.RyuutamaActor;

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/autumns-dusk-qgZtlvxXj6fru9po.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/autumns-dusk-qgZtlvxXj6fru9po.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Autumn's Dusk",
+  "type": "standard",
+  "_id": "qgZtlvxXj6fru9po",
+  "img": "icons/creatures/birds/birds-flock-fly-yellow.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You may fly with a flock of migrating birds to their same destination.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 2,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777737348002,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!qgZtlvxXj6fru9po"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/beautification-qIS8L59TcPqMiaAx.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/beautification-qIS8L59TcPqMiaAx.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Beautification",
+  "type": "standard",
+  "_id": "qIS8L59TcPqMiaAx",
+  "img": "icons/skills/toxins/cauldron-pot-bubbles-green.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your hairstyle and hair color are changed, and makeup is applied to fit a desired image.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777736956578,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!qIS8L59TcPqMiaAx"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/double-attack-HStnDBlOrtWAI0EB.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/double-attack-HStnDBlOrtWAI0EB.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Double Attack",
+  "type": "standard",
+  "_id": "HStnDBlOrtWAI0EB",
+  "img": "icons/skills/melee/swords-triple-orange.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You may attack twice each round.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777736827081,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!HStnDBlOrtWAI0EB"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/dragonfly-wings-Lp6Anof4RbTJzxrQ.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/dragonfly-wings-Lp6Anof4RbTJzxrQ.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Dragonfly Wings",
+  "type": "standard",
+  "_id": "Lp6Anof4RbTJzxrQ",
+  "img": "icons/creatures/abilities/wings-birdlike-blue.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You have wings and can fly at 30 km/hour and move in the air as freely as if you were on land. The wings give neither bonuses nor penalties while in combat.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777736689803,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!Lp6Anof4RbTJzxrQ"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/grave-glacier-Zo1XYK0B65E2fZtE.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/grave-glacier-Zo1XYK0B65E2fZtE.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Grave Glacier",
+  "type": "standard",
+  "_id": "Zo1XYK0B65E2fZtE",
+  "img": "icons/magic/water/barrier-ice-water-cube.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You are frozen in a glacier, trapped until the ice melts.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 2,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777737670600,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!Zo1XYK0B65E2fZtE"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/luck-maCvOScX9b09ZNeR.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/luck-maCvOScX9b09ZNeR.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Luck",
+  "type": "standard",
+  "_id": "maCvOScX9b09ZNeR",
+  "img": "icons/commodities/treasure/brooch-lightning-gold.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You may reroll one check.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777737048170,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!maCvOScX9b09ZNeR"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/safety-zero-suMIvgE9PeDXW5YS.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/safety-zero-suMIvgE9PeDXW5YS.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Safety Zero",
+  "type": "standard",
+  "_id": "suMIvgE9PeDXW5YS",
+  "img": "icons/magic/defensive/armor-green-hex.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>One time when you take damage that would take your HP to 0 or below, you are instead left with 1 HP.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777736547210,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!suMIvgE9PeDXW5YS"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/seven-fortune-frigate-pGA2W360B8jMxxRs.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/seven-fortune-frigate-pGA2W360B8jMxxRs.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Seven Fortune Frigate",
+  "type": "standard",
+  "_id": "pGA2W360B8jMxxRs",
+  "img": "icons/magic/air/wind-weather-sailing-ship.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>All your Fumbles turn into Criticals.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777726317370,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!pGA2W360B8jMxxRs"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-dexterity-sproutdexterity0.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-dexterity-sproutdexterity0.json
@@ -1,0 +1,45 @@
+{
+  "name": "Sprout Ability: Dexterity",
+  "img": "systems/ryuutama/assets/official/icons/stats/dexterity.svg",
+  "folder": "yc3IkYrl8DC5mUUu",
+  "_id": "sproutdexterity0",
+  "description": "<p>If your Dexterity was currently 12, it has been raised to 20.</p>",
+  "system": {
+    "changes": [
+      {
+        "key": "system.abilities.dexterity.value",
+        "type": "override",
+        "value": 20,
+        "phase": "initial"
+      }
+    ]
+  },
+  "type": "standard",
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724673161,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!sproutdexterity0"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-intelligence-sproutintelligen.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-intelligence-sproutintelligen.json
@@ -1,0 +1,45 @@
+{
+  "name": "Sprout Ability: Intelligence",
+  "img": "systems/ryuutama/assets/official/icons/stats/intelligence.svg",
+  "folder": "yc3IkYrl8DC5mUUu",
+  "_id": "sproutintelligen",
+  "description": "<p>If your Intelligence was currently 12, it has been raised to 20.</p>",
+  "system": {
+    "changes": [
+      {
+        "key": "system.abilities.intelligence.value",
+        "type": "override",
+        "value": 20,
+        "phase": "initial"
+      }
+    ]
+  },
+  "type": "standard",
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724673162,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!sproutintelligen"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-spirit-sproutspirit0000.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-spirit-sproutspirit0000.json
@@ -1,0 +1,45 @@
+{
+  "name": "Sprout Ability: Spirit",
+  "img": "systems/ryuutama/assets/official/icons/stats/spirit.svg",
+  "folder": "yc3IkYrl8DC5mUUu",
+  "_id": "sproutspirit0000",
+  "description": "<p>If your Spirit was currently 12, it has been raised to 20.</p>",
+  "system": {
+    "changes": [
+      {
+        "key": "system.abilities.spirit.value",
+        "type": "override",
+        "value": 20,
+        "phase": "initial"
+      }
+    ]
+  },
+  "type": "standard",
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724673162,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!sproutspirit0000"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-strength-sproutstrength00.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/sprout-ability-strength-sproutstrength00.json
@@ -1,0 +1,45 @@
+{
+  "name": "Sprout Ability: Strength",
+  "img": "systems/ryuutama/assets/official/icons/stats/strength.svg",
+  "folder": "yc3IkYrl8DC5mUUu",
+  "_id": "sproutstrength00",
+  "description": "<p>If your Strength was currently 12, it has been raised to 20.</p>",
+  "system": {
+    "changes": [
+      {
+        "key": "system.abilities.strength.value",
+        "type": "override",
+        "value": 20,
+        "phase": "initial"
+      }
+    ]
+  },
+  "type": "standard",
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724673161,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!sproutstrength00"
+}

--- a/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/winter-sleep-VZ9DkJrrYgxJ4Zep.json
+++ b/src/effects/buffs-and-debuffs-yc3IkYrl8DC5mUUu/winter-sleep-VZ9DkJrrYgxJ4Zep.json
@@ -1,0 +1,38 @@
+{
+  "folder": "yc3IkYrl8DC5mUUu",
+  "name": "Winter Sleep",
+  "type": "standard",
+  "_id": "VZ9DkJrrYgxJ4Zep",
+  "img": "icons/magic/time/day-night-sunset-sunrise.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You are asleep. On each of your actions, you may attempt to wake up by rolling a [[/check str spi]] check with a target number of 6. If you succeed, you awaken, but you turn is over. If you take any damage, you immediately wake up.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 2,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777726663279,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!VZ9DkJrrYgxJ4Zep"
+}

--- a/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/_folder.json
+++ b/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/_folder.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": null,
+  "name": "Check Bonuses",
+  "color": null,
+  "sorting": "a",
+  "_id": "Kz6HA1kRTPikWSfJ",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724806352,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!Kz6HA1kRTPikWSfJ"
+}

--- a/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/accuracy-1-KE3Lifqh15JtAZqC.json
+++ b/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/accuracy-1-KE3Lifqh15JtAZqC.json
@@ -1,0 +1,38 @@
+{
+  "folder": "Kz6HA1kRTPikWSfJ",
+  "name": "Accuracy +1",
+  "type": "standard",
+  "_id": "KE3Lifqh15JtAZqC",
+  "img": "icons/skills/targeting/triangle-glow-blue.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You have a +1 bonus to Accuracy checks.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724946737,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!KE3Lifqh15JtAZqC"
+}

--- a/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/accuracy-2-QUEJLDZ8vjdeayLy.json
+++ b/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/accuracy-2-QUEJLDZ8vjdeayLy.json
@@ -1,0 +1,38 @@
+{
+  "folder": "Kz6HA1kRTPikWSfJ",
+  "name": "Accuracy -2",
+  "type": "standard",
+  "_id": "QUEJLDZ8vjdeayLy",
+  "img": "icons/skills/targeting/crosshair-hex-red.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You have a -2 penalty to Accuracy checks.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777725236102,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!QUEJLDZ8vjdeayLy"
+}

--- a/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/camping-2-85ItUEZjQY2OHgSn.json
+++ b/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/camping-2-85ItUEZjQY2OHgSn.json
@@ -1,0 +1,38 @@
+{
+  "folder": "Kz6HA1kRTPikWSfJ",
+  "name": "Camping +2",
+  "type": "standard",
+  "_id": "85ItUEZjQY2OHgSn",
+  "img": "icons/environment/settlement/house-woods.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You have a +2 bonus to Camping checks.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777725019249,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!85ItUEZjQY2OHgSn"
+}

--- a/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/direction-1-LOUhDCl49x8r7e8x.json
+++ b/src/effects/check-bonuses-Kz6HA1kRTPikWSfJ/direction-1-LOUhDCl49x8r7e8x.json
@@ -1,0 +1,38 @@
+{
+  "folder": "Kz6HA1kRTPikWSfJ",
+  "name": "Direction +1",
+  "type": "standard",
+  "_id": "LOUhDCl49x8r7e8x",
+  "img": "icons/tools/navigation/watch-simple-blue.webp",
+  "system": {
+    "changes": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You have a +1 bonus to Direction checks.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.360",
+    "systemId": "ryuutama",
+    "systemVersion": "2.1.0",
+    "createdTime": 1777724816650,
+    "modifiedTime": null,
+    "lastModifiedBy": "ryuutama00000000",
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!LOUhDCl49x8r7e8x"
+}

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/anywhere-cottage-anywherecottage0.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/anywhere-cottage-anywherecottage0.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.85ItUEZjQY2OHgSn"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906423,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731660,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/bloodbath-blades-bloodbathblades0.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/bloodbath-blades-bloodbathblades0.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "bloodbath-blades"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906427,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731662,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-banquet-dragonbanquet000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-banquet-dragonbanquet000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906430,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731667,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-fly-dragonfly0000000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-fly-dragonfly0000000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 10,
+            "units": "minutes"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.Lp6Anof4RbTJzxrQ"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906430,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731667,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-sign-dragonsign000000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/dragon-sign-dragonsign000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 1,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906431,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731668,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/hayabusa-hayabusa00000000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/hayabusa-hayabusa00000000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.HStnDBlOrtWAI0EB"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906432,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731670,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/rainbow-drop-bridge-rainbowdropbridg.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/rainbow-drop-bridge-rainbowdropbridg.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906434,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731675,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/replica-replica000000000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/replica-replica000000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731676,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/war-metafield-warmetafield0000.json
+++ b/src/spells/incantation-magic-incantation00000/high-level-incantationhigh0/war-metafield-warmetafield0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906438,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731680,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/alert-bell-alarm-alertbellalarm00.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/alert-bell-alarm-alertbellalarm00.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906422,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731659,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/animal-tamer-animaltamer00000.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/animal-tamer-animaltamer00000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906423,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731659,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/arrow-compass-arrowcompass0000.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/arrow-compass-arrowcompass0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906423,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731660,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/cure-touch-curetouch0000000.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/cure-touch-curetouch0000000.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "cure-touch"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906429,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731666,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/enhanced-red-hand-enhancedredhand0.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/enhanced-red-hand-enhancedredhand0.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.KE3Lifqh15JtAZqC"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906431,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731669,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/pure-crystalight-purecrystalight0.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/pure-crystalight-purecrystalight0.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.ardACIbaGO8EzWiI"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906434,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731675,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/round-reflection-roundreflection0.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/round-reflection-roundreflection0.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.O8to3AzaVpBDczLS"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731677,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/shooting-star-shootingstar0000.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/shooting-star-shootingstar0000.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "shooting-star"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906436,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731677,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/tastegood-taste-tastegoodtaste00.json
+++ b/src/spells/incantation-magic-incantation00000/low-level-incantationlow00/tastegood-taste-tastegoodtaste00.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731679,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/attack-of-the-killer-object-attackofthekille.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/attack-of-the-killer-object-attackofthekille.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "attack-of-the-killer-object"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906424,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731660,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/cats-drive-catsdrive0000000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/cats-drive-catsdrive0000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906428,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731664,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/dragonica-open-dragonicaopen000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/dragonica-open-dragonicaopen000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906430,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731667,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/elfwish-elfwish000000000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/elfwish-elfwish000000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906431,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731668,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/knights-of-cleaning-knightsofcleanin.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/knights-of-cleaning-knightsofcleanin.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906432,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731671,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/magematik-shield-magematikshield0.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/magematik-shield-magematikshield0.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.wgOmFK37FwUJO3uv"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 10,
+            "units": "minutes"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906433,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731673,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/remove-touch-removetouch00000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/remove-touch-removetouch00000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906434,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731675,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/safety-zero-safetyzero000000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/safety-zero-safetyzero000000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.suMIvgE9PeDXW5YS"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731677,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/type-wild-typewild00000000.json
+++ b/src/spells/incantation-magic-incantation00000/mid-level-incantationmid00/type-wild-typewild00000000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.CaaKV1IzQUB4Tv1l"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731679,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/autumn-sky-autumnsky0000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/autumn-sky-autumnsky0000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394818,
+    "createdTime": 1777770731661,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/autumns-dusk-autumnsdusk00000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/autumns-dusk-autumnsdusk00000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": null,
+            "units": "seconds"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.qgZtlvxXj6fru9po"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +74,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394818,
+    "createdTime": 1777770731661,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/lie-lie0000000000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/lie-lie0000000000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394820,
+    "createdTime": 1777770731672,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/rin-rin-relaxing-orchestra-rinrinrelaxingor.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/high-level-fallhigh00000000/rin-rin-relaxing-orchestra-rinrinrelaxingor.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394820,
+    "createdTime": 1777770731676,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/fallen-leaves-fallenleaves0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/fallen-leaves-fallenleaves0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394819,
+    "createdTime": 1777770731669,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/harvest-moon-harvestmoon00000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/harvest-moon-harvestmoon00000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394819,
+    "createdTime": 1777770731670,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/magic-jam-bottle-magicjambottle00.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/magic-jam-bottle-magicjambottle00.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394820,
+    "createdTime": 1777770731673,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/otome-tears-otometears000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/low-level-falllow000000000/otome-tears-otometears000000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.QUEJLDZ8vjdeayLy"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +74,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394820,
+    "createdTime": 1777770731674,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/chocolate-cosmos-chocolatecosmos0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/chocolate-cosmos-chocolatecosmos0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394818,
+    "createdTime": 1777770731664,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/grateful-scarecrow-gratefulscarecro.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/grateful-scarecrow-gratefulscarecro.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394819,
+    "createdTime": 1777770731670,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/mignon-bivouac-mignonbivouac000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/mignon-bivouac-mignonbivouac000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.HaHX7babrqTDFSsu"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +74,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394820,
+    "createdTime": 1777770731674,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/spirit-of-obon-spiritofobon0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/fall-magic-fall000000000000/mid-level-fallmid000000000/spirit-of-obon-spiritofobon0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -58,7 +72,7 @@
     "coreVersion": "14.360",
     "systemId": "ryuutama",
     "systemVersion": "2.1.0",
-    "createdTime": 1777252394821,
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/cure-plus-xl-cureplusxl000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/cure-plus-xl-cureplusxl000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906429,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731665,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/resurrection-kiss-resurrectionkiss.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/resurrection-kiss-resurrectionkiss.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731676,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/springs-daybreak-springsdaybreak0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/springs-daybreak-springsdaybreak0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906436,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/sprout-sprout0000000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/high-level-springhigh000000/sprout-sprout0000000000.json
@@ -38,6 +38,25 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.sproutdexterity0",
+            "Compendium.ryuutama.effects.ActiveEffect.sproutintelligen",
+            "Compendium.ryuutama.effects.ActiveEffect.sproutspirit0000",
+            "Compendium.ryuutama.effects.ActiveEffect.sproutstrength00"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +74,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906436,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/a-little-beauty-alittlebeauty000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/a-little-beauty-alittlebeauty000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 1,
+            "units": "days"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.qIS8L59TcPqMiaAx"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906423,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731659,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/cure-plus-plus-cureplusplus0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/cure-plus-plus-cureplusplus0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906429,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731665,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/emina-nonno-eminanonno000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/emina-nonno-eminanonno000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 1,
+            "units": "days"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906431,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731669,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/wake-up-and-stand-up-wakeupandstandup.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/low-level-springlow0000000/wake-up-and-stand-up-wakeupandstandup.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731680,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/detect-loveheart-detectloveheart0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/detect-loveheart-detectloveheart0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906430,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731666,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/kaguyas-leylance-kaguyasleylance0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/kaguyas-leylance-kaguyasleylance0.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "kaguyas-leylance"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906432,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731671,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/luck-luck-luck-luckluckluck0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/luck-luck-luck-luckluckluck0000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.maCvOScX9b09ZNeR"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906433,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731673,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/rose-fever-scatter-rosefeverscatter.json
+++ b/src/spells/seasonal-magic-seasonal00000000/spring-magic-spring0000000000/mid-level-springmid0000000/rose-fever-scatter-rosefeverscatter.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731676,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/be-brave-bebrave000000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/be-brave-bebrave000000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906426,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731661,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/cyclone-cyclone000000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/cyclone-cyclone000000000.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "cyclone"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906430,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731666,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/summers-midnight-summersmidnight0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/summers-midnight-summersmidnight0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 1,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/tanabatas-wish-tanabataswish000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/high-level-summerhigh000000/tanabatas-wish-tanabataswish000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/briar-nonno-briarnonno000000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/briar-nonno-briarnonno000000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906427,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731662,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/koro-pok-kuru-cute-leaf-koropokkurucutel.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/koro-pok-kuru-cute-leaf-koropokkurucutel.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906433,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731672,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/min-min-cicada-chorus-minmincicadachor.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/min-min-cicada-chorus-minmincicadachor.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906434,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731674,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/vacation-vitality-vacationvitality.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/low-level-summerlow0000000/vacation-vitality-vacationvitality.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.tLpaBGrOlEZoZyrs"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731679,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/call-squall-code-callsquallcode00.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/call-squall-code-callsquallcode00.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 10,
+            "units": "minutes"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906427,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731662,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/lightning-bug-net-lightningbugnet0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/lightning-bug-net-lightningbugnet0.json
@@ -5,7 +5,7 @@
       "value": "summer"
     },
     "description": {
-      "value": "<p>Summons a tent of magical mosquito netting that zaps approaching bugs. Grants a +2 bonus to Camp Checks in areas with flying insects.</p>"
+      "value": "<p>Summons a tent of magical mosquito netting that zaps approaching bugs. Grants a +2 bonus to Camping Checks in areas with flying insects.</p>"
     },
     "spell": {
       "activation": {
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.85ItUEZjQY2OHgSn"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906433,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731672,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/scarlet-passion-scarletpassion00.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/scarlet-passion-scarletpassion00.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906435,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731677,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/the-illness-of-may-theillnessofmay0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/summer-magic-summer0000000000/mid-level-summermid0000000/the-illness-of-may-theillnessofmay0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906437,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731679,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/absolute-zero-clock-absolutezerocloc.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/absolute-zero-clock-absolutezerocloc.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 4,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906422,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731658,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/grave-glacier-graveglacier0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/grave-glacier-graveglacier0000.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": null,
+            "units": "seconds"
+          },
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.Zo1XYK0B65E2fZtE"
+          ],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906432,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731670,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/seven-fortune-frigate-sevenfortunefrig.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/seven-fortune-frigate-sevenfortunefrig.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.pGA2W360B8jMxxRs"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906436,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731677,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/winters-early-morning-wintersearlymorn.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/high-level-winterhigh000000/winters-early-morning-wintersearlymorn.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906438,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731681,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/candy-ice-cube-candyicecube0000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/candy-ice-cube-candyicecube0000.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 10,
+            "units": "minutes"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906428,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731662,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/cool-masquerade-coolmasquerade00.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/cool-masquerade-coolmasquerade00.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.qhQLDw0Q8kjHLbyS"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906429,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731665,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/snowball-storm-snowballstorm000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/snowball-storm-snowballstorm000.json
@@ -37,6 +37,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     },
     "identifier": "snowball-storm"
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906436,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731678,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/winter-sleep-wintersleep00000.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/low-level-winterlow0000000/winter-sleep-wintersleep00000.json
@@ -5,7 +5,7 @@
       "value": "winter"
     },
     "description": {
-      "value": "<p>The targets feels the lethargy of winter overcome them, and they fall asleep. On the targets' next action and every action thereafter, they may attempt to wake up by rolling a [[/check check \"@stats.strength + @stats.spirit\"]]{[STR + SPI]} check with a target number of 6. If they succeed, they awaken, but their turn is over. If a sleeping creature takes any damage, they immediately wake up.</p>"
+      "value": "<p>The targets feels the lethargy of winter overcome them, and they fall asleep. On the targets' next action and every action thereafter, they may attempt to wake up by rolling a [[/check str spi]] check with a target number of 6. If they succeed, they awaken, but their turn is over. If a sleeping creature takes any damage, they immediately wake up.</p>"
     },
     "spell": {
       "activation": {
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.VZ9DkJrrYgxJ4Zep"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906438,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731681,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/catch-an-evil-wind-catchanevilwind0.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/catch-an-evil-wind-catchanevilwind0.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "units": "seconds",
+            "value": null
+          },
+          "riders": {
+            "items": []
+          },
+          "self": false,
+          "uuids": []
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906428,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731664,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/icesword-of-desire-iceswordofdesire.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/icesword-of-desire-iceswordofdesire.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 1,
+            "units": "hours"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906432,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731671,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/magical-kotatsu-mikan-magicalkotatsuan.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/magical-kotatsu-mikan-magicalkotatsuan.json
@@ -38,6 +38,22 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "uuids": [
+            "Compendium.ryuutama.effects.ActiveEffect.85ItUEZjQY2OHgSn"
+          ],
+          "riders": {
+            "items": []
+          },
+          "duration": {
+            "value": 12,
+            "units": "hours"
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +71,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906433,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731673,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/pirika-crackle-static-pirikacracklesta.json
+++ b/src/spells/seasonal-magic-seasonal00000000/winter-magic-winter0000000000/mid-level-wintermid0000000/pirika-crackle-static-pirikacracklesta.json
@@ -38,6 +38,20 @@
       "healing": {
         "formula": "",
         "properties": []
+      },
+      "effects": {
+        "config": {
+          "duration": {
+            "value": 6,
+            "units": "rounds"
+          },
+          "uuids": [],
+          "riders": {
+            "items": []
+          },
+          "self": false
+        },
+        "statuses": {}
       }
     }
   },
@@ -55,10 +69,10 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.357",
+    "coreVersion": "14.360",
     "systemId": "ryuutama",
-    "systemVersion": "2.0.0",
-    "createdTime": 1774638906434,
+    "systemVersion": "2.1.0",
+    "createdTime": 1777770731674,
     "modifiedTime": null,
     "lastModifiedBy": "ryuutama00000000"
   },

--- a/styles/sheets/item-sheet.css
+++ b/styles/sheets/item-sheet.css
@@ -11,4 +11,17 @@
     text-align: center;
     font-style: italic;
   }
+
+  .action-status-row {
+    justify-content: space-between;
+
+    input {
+      text-align: center;
+      flex: 0 0 3rem;
+    }
+
+    a {
+      flex: none;
+    }
+  }
 }

--- a/templates/chat/effect-select.hbs
+++ b/templates/chat/effect-select.hbs
@@ -1,0 +1,9 @@
+{{#each options}}
+<div class="form-group slim" data-tooltip-direction="LEFT">
+  <label for="{{@root.rootId}}-{{value}}" data-tooltip-html="{{ryuutama-tooltip uuid=uuid}}">{{label}}</label>
+  <div class="form-fields">
+    <input type="radio" name="dependency" id="{{@root.rootId}}-{{value}}" value="{{value}}" {{checked checked}}>
+  </div>
+</div>
+{{/each}}
+<p class="hint">{{localize "RYUUTAMA.ITEM.ACTIONS.selectEffectHint"}}</p>

--- a/templates/chat/parts/effect.hbs
+++ b/templates/chat/parts/effect.hbs
@@ -2,27 +2,12 @@
 <span class="flavor">{{part.flavor}}</span>
 {{/if}}
 
-<section class="effect-list">
-  {{#each ctx.effects}}
-  <span class="effect" data-effect-uuid="{{effect.uuid}}">
-    <img src="{{effect.img}}" alt="{{effect.name}}" data-tooltip-html="{{ryuutama-tooltip uuid=effect.uuid}}">
-    <span class="name">{{effect.name}}</span>
-    <input type="checkbox" {{checked checked}}>
-  </span>
-  {{/each}}
-  {{#each ctx.statuses}}
-  <span class="effect" data-status-id="{{statusId}}">
-    <img src="{{icon}}" alt="{{label}}">
-    <span class="name">{{label}}</span>
-    <input type="checkbox" {{checked checked}}>
-  </span>
-  {{/each}}
-</section>
-
 <section>
+  {{#if ctx.showTray}}
   <effect-tray></effect-tray>
+  {{/if}}
   <button type="button" data-action="applyEffects">
-    <i class="fa-solid fa-burst" inert></i>
+    <i class="fa-solid fa-person-rays" inert></i>
     <span>{{localize "RYUUTAMA.CHAT.EFFECT.applyEffects"}}</span>
   </button>
 </section>

--- a/templates/sheets/item-sheet/actions.hbs
+++ b/templates/sheets/item-sheet/actions.hbs
@@ -1,17 +1,59 @@
 <section data-tab="{{tabs.actions.id}}" class="{{tabs.actions.cssClass}}" data-group="{{tabs.actions.group}}">
   {{#with actions}}
+
+  {{> "templates/generic/tab-navigation.hbs" tabs=tabs}}
+
   {{!-- DAMAGE --}}
-  <fieldset>
-    <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.damage"}}</legend>
-    {{formGroup fields.damage.fields.formula value=document.damage.formula disabled=@root.disabled rootId=@root.rootId}}
-    {{formGroup fields.damage.fields.properties value=document.damage.properties options=damageOptions disabled=@root.disabled type="checkboxes" classes="stacked"}}
-  </fieldset>
+  <section data-tab="{{tabs.actionDamage.id}}" class="tab {{tabs.actionDamage.cssClass}}" data-group="{{tabs.actionDamage.group}}">
+    <fieldset>
+      <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.damage"}}</legend>
+      {{formGroup fields.damage.fields.formula value=document.damage.formula disabled=@root.disabled rootId=@root.rootId}}
+      {{formGroup fields.damage.fields.properties value=document.damage.properties options=damageOptions disabled=@root.disabled type="checkboxes" classes="stacked"}}
+    </fieldset>
+  </section>
 
   {{!-- HEALING --}}
-  <fieldset>
-    <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.healing"}}</legend>
-    {{formGroup fields.healing.fields.formula value=document.healing.formula disabled=@root.disabled rootId=@root.rootId}}
-    {{!-- {{formGroup fields.healing.fields.properties value=document.healing.properties options=healingOptions disabled=@root.disabled type="checkboxes" classes="stacked"}} --}}
-  </fieldset>
+  <section data-tab="{{tabs.actionHealing.id}}" class="tab {{tabs.actionHealing.cssClass}}" data-group="{{tabs.actionHealing.group}}">
+    <fieldset>
+      <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.healing"}}</legend>
+      {{formGroup fields.healing.fields.formula value=document.healing.formula disabled=@root.disabled rootId=@root.rootId}}
+      {{!-- {{formGroup fields.healing.fields.properties value=document.healing.properties options=healingOptions disabled=@root.disabled type="checkboxes" classes="stacked"}} --}}
+    </fieldset>
+  </section>
+
+  {{!-- EFFECTS --}}
+  <section data-tab="{{tabs.actionEffects.id}}" class="tab {{tabs.actionEffects.cssClass}}" data-group="{{tabs.actionEffects.group}}">
+    <fieldset>
+      <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.statuses"}}</legend>
+      <p class="hint">{{localize "RYUUTAMA.ITEM.ACTIONS.statusesHint"}}</p>
+      {{#each statuses}}
+      {{#if display}}
+      <div class="form-group" data-status="{{status}}">
+        <label for="{{id}}">{{label}}</label>
+        <div class="form-fields action-status-row">
+          {{formInput field type="number" value=strength name=name disabled=disabledInput id=id}}
+          <a class="{{icon}}" {{disabled @root.disabled}} data-action="toggleActionEffectStatus"></a>
+        </div>
+      </div>
+      {{/if}}
+      {{/each}}
+    </fieldset>
+
+    <fieldset>
+      <legend>{{localize "RYUUTAMA.ITEM.ACTIONS.effectApplied"}}</legend>
+      <div class="form-group slim">
+        <label for="{{@root.rootId}}-{{effectConfig.fields.duration.fields.units.fieldPath}}">{{localize "RYUUTAMA.ITEM.ACTIONS.durationLabel"}}</label>
+        <div class="form-fields">
+          {{formInput effectConfig.fields.duration.fields.value value=effectConfig.values.duration.value placeholder="-" disabled=@root.disabled}}
+          {{formInput effectConfig.fields.duration.fields.units value=effectConfig.values.duration.units id=(concat @root.rootId "-" effectConfig.fields.duration.fields.units.fieldPath) options=effectConfig.durationOptions disabled=@root.disabled}}
+        </div>
+        <p class="hint">{{localize "RYUUTAMA.ITEM.ACTIONS.durationHint"}}</p>
+      </div>
+      {{formGroup effectConfig.fields.uuids value=effectConfig.values.uuids disabled=@root.disabled rootId=@root.rootId}}
+      {{formGroup effectConfig.fields.self value=effectConfig.values.self disabled=@root.disabled rootId=@root.rootId}}
+      {{formGroup effectConfig.fields.riders.fields.items value=effectConfig.values.riders.items disabled=@root.disabled rootId=@root.rootId}}
+    </fieldset>
+  </section>
+
   {{/with}}
 </section>


### PR DESCRIPTION
Closes #361 and #151.

- Prevent drops of documents onto the document sheet from doing anything further if the target is a `document-tags` element.
- Widen the item sheet and adds tabs for the different action types.
- On item sheet, only add effects to the item if dropped onto the primary Effects tab.
- Sets the expiry action to be "delete" when effects expire.
- Adds a lot more effects to the compendium and refreshes all the spell items.

This PR adds all the data for applying effects and statuses from an item routed through the `EffectPart` message part.

TODO:
- [x] Merge current structure into just being an embedded model at `system.actions.effects`.
- [x] Some general cleanup.
- [x] Update `_types`.